### PR TITLE
Extend tasks interface

### DIFF
--- a/interfaces/fimo_tasks_int/Cargo.toml
+++ b/interfaces/fimo_tasks_int/Cargo.toml
@@ -11,5 +11,6 @@ categories = ["game-development"]
 [dependencies]
 log = "0.4.14"
 atomic = "0.5.1"
+rand = { version = "0.8.5", features = ["small_rng"] }
 fimo_ffi = { version = "0.1.0", path = "../../utilities/fimo_ffi" }
 fimo_module = { version = "0.1.0", path = "../../utilities/fimo_module" }

--- a/interfaces/fimo_tasks_int/src/lib.rs
+++ b/interfaces/fimo_tasks_int/src/lib.rs
@@ -6,6 +6,7 @@
     rustdoc::broken_intra_doc_links
 )]
 #![feature(const_ptr_offset_from)]
+#![feature(strict_provenance)]
 #![feature(negative_impls)]
 #![feature(const_mut_refs)]
 #![feature(thread_local)]

--- a/interfaces/fimo_tasks_int/src/lib.rs
+++ b/interfaces/fimo_tasks_int/src/lib.rs
@@ -18,6 +18,8 @@ use crate::runtime::{IRuntime, IRuntimeExt};
 use fimo_ffi::{interface, DynObj};
 use fimo_module::{FimoInterface, IModuleInterface, IModuleInterfaceVTable, ReleaseType, Version};
 
+pub mod sync;
+
 pub mod raw;
 pub mod runtime;
 pub mod task;

--- a/interfaces/fimo_tasks_int/src/raw.rs
+++ b/interfaces/fimo_tasks_int/src/raw.rs
@@ -285,6 +285,16 @@ impl Default for Builder {
     }
 }
 
+/// A task that is always blocked and bound to an address.
+///
+/// Useful for the implementation of synchronization primitives.
+#[repr(transparent)]
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PseudoTask(pub *const ());
+
+unsafe impl Send for PseudoTask {}
+unsafe impl Sync for PseudoTask {}
+
 /// Interface of a raw task.
 #[interface(
     uuid = "fa8ec56f-9c02-4ad1-9845-814310169d73",

--- a/interfaces/fimo_tasks_int/src/raw.rs
+++ b/interfaces/fimo_tasks_int/src/raw.rs
@@ -101,19 +101,6 @@ pub enum TaskScheduleStatus {
     Finished,
 }
 
-/// Data passed to a task upon wakeup.
-#[repr(C, u8)]
-#[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, PartialEq, Eq)]
-pub enum WakeupData {
-    /// Wake up without any data.
-    None,
-    /// Custom data passed to the task.
-    Custom(*const ()),
-}
-
-/// The passed data transfers ownership of the contents.
-unsafe impl Send for WakeupData {}
-
 /// Representation of a raw task.
 #[derive(ObjectId)]
 #[fetch_vtable(uuid = "eb91ee4a-22d2-4b91-9e06-0994f0d79b0f", interfaces(IRawTask))]

--- a/interfaces/fimo_tasks_int/src/raw.rs
+++ b/interfaces/fimo_tasks_int/src/raw.rs
@@ -101,6 +101,19 @@ pub enum TaskScheduleStatus {
     Finished,
 }
 
+/// Data passed to a task upon wakeup.
+#[repr(C, u8)]
+#[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, PartialEq, Eq)]
+pub enum WakeupData {
+    /// Wake up without any data.
+    None,
+    /// Custom data passed to the task.
+    Custom(*const ()),
+}
+
+/// The passed data transfers ownership of the contents.
+unsafe impl Send for WakeupData {}
+
 /// Representation of a raw task.
 #[derive(ObjectId)]
 #[fetch_vtable(uuid = "eb91ee4a-22d2-4b91-9e06-0994f0d79b0f", interfaces(IRawTask))]
@@ -489,6 +502,9 @@ pub(crate) struct SchedulerContextInner<'a> {
     scheduler_data: Option<ObjBox<DynObj<dyn IBase + Send + Sync + 'static>>>,
     _pinned: PhantomPinned,
 }
+
+struct SendWrapper<T>(T);
+unsafe impl<T> Send for SendWrapper<T> {}
 
 struct SyncWrapper<T> {
     init: bool,

--- a/interfaces/fimo_tasks_int/src/runtime.rs
+++ b/interfaces/fimo_tasks_int/src/runtime.rs
@@ -207,14 +207,14 @@ pub trait IRuntimeExt: IRuntime {
     /// Can only be called from a worker thread.
     #[inline]
     #[track_caller]
-    fn spawn<'th, 'a, 'b, F, R>(
-        &'th self,
+    fn spawn<F, R>(
+        &self,
         f: F,
-        wait_on: &'a [TaskHandle],
-    ) -> fimo_module::Result<JoinHandle<Pin<ObjBox<Task<'b, R>>>>>
+        wait_on: &[TaskHandle],
+    ) -> fimo_module::Result<JoinHandle<Pin<ObjBox<Task<'static, R>>>>>
     where
-        F: FnOnce() -> R + Send + 'b,
-        R: Send + 'b,
+        F: FnOnce() -> R + Send + 'static,
+        R: Send + 'static,
     {
         Builder::new().spawn(f, wait_on)
     }

--- a/interfaces/fimo_tasks_int/src/sync.rs
+++ b/interfaces/fimo_tasks_int/src/sync.rs
@@ -1,11 +1,13 @@
 //! Synchronization primitives
 //!
 //! This module provides Runtime-aware implementations
-//! of `Mutex`, `RWLock` and `Condvar`.
+//! of `Mutex`, `RWLock`, `Condvar` and `Barrier`.
 
+mod barrier;
 mod condvar;
 mod mutex;
 mod spin_wait;
 
+pub use barrier::Barrier;
 pub use condvar::Condvar;
 pub use mutex::{Mutex, MutexGuard};

--- a/interfaces/fimo_tasks_int/src/sync.rs
+++ b/interfaces/fimo_tasks_int/src/sync.rs
@@ -3,7 +3,9 @@
 //! This module provides Runtime-aware implementations
 //! of `Mutex`, `RWLock` and `Condvar`.
 
+mod condvar;
 mod mutex;
 mod spin_wait;
 
+pub use condvar::Condvar;
 pub use mutex::{Mutex, MutexGuard};

--- a/interfaces/fimo_tasks_int/src/sync.rs
+++ b/interfaces/fimo_tasks_int/src/sync.rs
@@ -6,8 +6,10 @@
 mod barrier;
 mod condvar;
 mod mutex;
+mod rwlock;
 mod spin_wait;
 
-pub use barrier::Barrier;
+pub use barrier::{Barrier, BarrierWaitResult};
 pub use condvar::Condvar;
 pub use mutex::{Mutex, MutexGuard};
+pub use rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};

--- a/interfaces/fimo_tasks_int/src/sync.rs
+++ b/interfaces/fimo_tasks_int/src/sync.rs
@@ -1,0 +1,9 @@
+//! Synchronization primitives
+//!
+//! This module provides Runtime-aware implementations
+//! of `Mutex`, `RWLock` and `Condvar`.
+
+mod mutex;
+mod spin_wait;
+
+pub use mutex::{Mutex, MutexGuard};

--- a/interfaces/fimo_tasks_int/src/sync/barrier.rs
+++ b/interfaces/fimo_tasks_int/src/sync/barrier.rs
@@ -1,0 +1,90 @@
+// Taken from the implementation of the std Barrier.
+use crate::sync::{Condvar, Mutex};
+use std::fmt::{Debug, Formatter};
+
+/// A barrier enables multiple threads to synchronize the beginning
+/// of some computation.
+pub struct Barrier {
+    lock: Mutex<BarrierState>,
+    cvar: Condvar,
+    num_threads: usize,
+}
+
+struct BarrierState {
+    count: usize,
+    generation_id: usize,
+}
+
+/// Result of a `Barrier` wait operation.
+pub struct BarrierWaitResult(bool);
+
+impl Debug for Barrier {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Barrier").finish_non_exhaustive()
+    }
+}
+
+impl Barrier {
+    /// Constructs a new `Barrier` that can block a given number of tasks.
+    ///
+    /// The barrier will block the first `n-1` tasks which call [`Barrier::wait()`]
+    /// and then wake up all tasks at once when the `n`th tasks calls [`Barrier::wait()`].
+    pub fn new(n: usize) -> Self {
+        Self {
+            lock: Mutex::new(BarrierState {
+                count: 0,
+                generation_id: 0,
+            }),
+            cvar: Condvar::new(),
+            num_threads: n,
+        }
+    }
+
+    /// Blocks the current task until all threads have rendezvoused here.
+    ///
+    /// Barriers are re-usable after all task have rendezvoused once,
+    /// and can be used continuously.
+    ///
+    /// A single (arbitrary) task will receive a BarrierWaitResult that returns
+    /// true from [`BarrierWaitResult::is_leader()`] when returning from this function,
+    /// and all other task will receive a result that will return false from
+    /// [`BarrierWaitResult::is_leader()`].
+    pub fn wait(&self) -> BarrierWaitResult {
+        let mut lock = self.lock.lock();
+        let local_gen = lock.generation_id;
+        lock.count += 1;
+        if lock.count < self.num_threads {
+            // We need a while loop to guard against spurious wakeups.
+            // https://en.wikipedia.org/wiki/Spurious_wakeup
+            //
+            // Note: The task runtime already prevents spurious wakeups,
+            // but this could change in the future.
+            self.cvar.wait_while(&mut lock, |l| {
+                local_gen == l.generation_id && l.count < self.num_threads
+            });
+            BarrierWaitResult(false)
+        } else {
+            lock.count = 0;
+            lock.generation_id = lock.generation_id.wrapping_add(1);
+            self.cvar.notify_all();
+            BarrierWaitResult(true)
+        }
+    }
+}
+
+impl Debug for BarrierWaitResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BarrierWaitResult")
+            .field("is_leader", &self.is_leader())
+            .finish()
+    }
+}
+
+impl BarrierWaitResult {
+    /// Returns true if this task is the “leader task” for the call to [Barrier::wait()].
+    ///
+    /// Only one task will be designated as the leader.
+    pub fn is_leader(&self) -> bool {
+        self.0
+    }
+}

--- a/interfaces/fimo_tasks_int/src/sync/condvar.rs
+++ b/interfaces/fimo_tasks_int/src/sync/condvar.rs
@@ -71,7 +71,7 @@ impl Condvar {
             }
 
             // Wait on the condvar task.
-            let wait = unsafe { s.pseudo_wait_task_on(curr, task, None, WaitToken::INVALID) };
+            let wait = unsafe { s.wait_task_on(curr, task, None, WaitToken::INVALID) };
             if let Err(e) = wait {
                 // On an error we abort and panic
                 if !preexisting_mutex {
@@ -169,10 +169,7 @@ impl Condvar {
             let mut callback = MaybeUninit::new(callback);
             let callback = unsafe { FfiFn::new_value(&mut callback) };
 
-            let result = unsafe {
-                s.pseudo_notify_one(task, callback)
-                    .expect("could not wake task")
-            };
+            let result = unsafe { s.notify_one(task, callback).expect("could not wake task") };
 
             if !result.has_tasks_remaining() {
                 unsafe {
@@ -228,7 +225,7 @@ impl Condvar {
             };
 
             let num = unsafe {
-                s.pseudo_notify_all(task, crate::runtime::WakeupToken::None)
+                s.notify_all(task, crate::runtime::WakeupToken::None)
                     .expect("could not wake task")
             };
 

--- a/interfaces/fimo_tasks_int/src/sync/condvar.rs
+++ b/interfaces/fimo_tasks_int/src/sync/condvar.rs
@@ -116,7 +116,7 @@ impl Condvar {
 
     /// Wakes up one blocked task on this condvar.
     ///
-    /// Returns whether a thread was woken up.
+    /// Returns whether a task was woken up.
     ///
     /// If there is a blocked task on this condition variable, then it will
     /// be woken up from its call to [`wait`]. Calls to `notify_one` are
@@ -167,13 +167,13 @@ impl Condvar {
 
     /// Wakes up all blocked task on this condvar.
     ///
-    /// Returns the number of threads woken up.
+    /// Returns the number of tasks woken up.
     ///
     /// This method will ensure that any current waiters on the condition
     /// variable are awoken. Calls to `notify_all()` are not buffered in any
     /// way.
     ///
-    /// To wake up only one thread, see [`notify_one`].
+    /// To wake up only one task, see [`notify_one`].
     ///
     /// [`notify_one`]: Self::notify_one
     #[inline]

--- a/interfaces/fimo_tasks_int/src/sync/condvar.rs
+++ b/interfaces/fimo_tasks_int/src/sync/condvar.rs
@@ -1,0 +1,207 @@
+use std::{fmt::Debug, pin::Pin, sync::atomic::AtomicPtr};
+
+use fimo_ffi::ObjBox;
+
+use crate::{
+    runtime::{current_runtime, IRuntimeExt, IScheduler},
+    task::{Builder, JoinHandle, Task},
+};
+
+use super::{mutex::RawMutex, MutexGuard};
+
+/// A Condition Variable
+///
+/// Condition variables represent the ability to block a task such that it
+/// consumes no CPU time while waiting for an event to occur. Condition
+/// variables are typically associated with a boolean predicate (a condition)
+/// and a mutex. The predicate is always verified inside of the mutex before
+/// determining that a task must block.
+///
+/// Functions in this module will block the current **task**.
+/// Note that any attempt to use multiple mutexes on the same condition
+/// variable may result in a runtime panic.
+pub struct Condvar {
+    state: AtomicPtr<RawMutex>,
+    raw: JoinHandle<Pin<ObjBox<Task<'static, ()>>>>,
+}
+
+impl Condvar {
+    /// Creates a new condition variable which is ready to be waited on and
+    /// notified.
+    #[inline]
+    pub fn new() -> Condvar {
+        let raw = Builder::new()
+            .blocked()
+            .spawn(|| {}, &[])
+            .expect("could not create condvar task");
+
+        Self {
+            state: AtomicPtr::new(std::ptr::null_mut()),
+            raw,
+        }
+    }
+
+    /// Blocks the current task until this condition variable receives a
+    /// notification.
+    ///
+    /// This function will atomically unlock the mutex specified (represented by
+    /// `guard`) and block the current task. This means that any calls
+    /// to [`notify_one`] or [`notify_all`] which happen logically after the
+    /// mutex is unlocked are candidates to wake this task up. When this
+    /// function call returns, the lock specified will have been re-acquired.
+    ///
+    /// Unlike the implementation in the std library, this function is not
+    /// susceptible to spurious wakeups.
+    ///
+    /// [`notify_one`]: Self::notify_one
+    /// [`notify_all`]: Self::notify_all
+    #[inline]
+    pub fn wait<'a, T>(&self, guard: &mut MutexGuard<'a, T>) {
+        let runtime = current_runtime().unwrap();
+        let raw = guard.as_raw();
+
+        runtime.yield_and_enter(|s, curr| {
+            let state = self.state.load(atomic::Ordering::Relaxed);
+            let state_const = state as *const RawMutex;
+
+            let preexisting_mutex = !state_const.is_null();
+
+            // Check that we are using the Condvar with only one mutex.
+            if preexisting_mutex && state_const != raw as *const RawMutex {
+                panic!("can not wait with differing mutexes")
+            }
+
+            if !preexisting_mutex {
+                self.state
+                    .store(raw as *const _ as *mut _, atomic::Ordering::Release);
+            }
+
+            // Wait on the condvar task.
+            let wait = unsafe { s.wait_task_on(curr, self.raw.as_raw(), None) };
+            if let Err(e) = wait {
+                // On an error we abort and panic
+                if !preexisting_mutex {
+                    self.state
+                        .store(std::ptr::null_mut(), atomic::Ordering::Release);
+                }
+
+                panic!("{}", e)
+            }
+
+            // Unlock the mutex.
+            unsafe { raw.unlock_condvar(s) };
+        });
+
+        // Lock the mutex again.
+        raw.lock()
+    }
+
+    /// Blocks the current task until this condition variable receives a
+    /// notification and the provided condition is false.
+    ///
+    /// This function will atomically unlock the mutex specified (represented by
+    /// `guard`) and block the current task. This means that any calls
+    /// to [`notify_one`] or [`notify_all`] which happen logically after the
+    /// mutex is unlocked are candidates to wake this task up. When this
+    /// function call returns, the lock specified will have been re-acquired.
+    ///
+    /// [`notify_one`]: Self::notify_one
+    /// [`notify_all`]: Self::notify_all
+    #[inline]
+    pub fn wait_while<'a, T, F>(&self, guard: &mut MutexGuard<'a, T>, mut condition: F)
+    where
+        F: FnMut(&mut T) -> bool,
+    {
+        while condition(&mut *guard) {
+            self.wait(guard);
+        }
+    }
+
+    /// Wakes up one blocked task on this condvar.
+    ///
+    /// Returns whether a thread was woken up.
+    ///
+    /// If there is a blocked task on this condition variable, then it will
+    /// be woken up from its call to [`wait`]. Calls to `notify_one` are
+    /// not buffered in any way.
+    ///
+    /// To wake up all task, see [`notify_all`].
+    ///
+    /// [`wait`]: Self::wait
+    /// [`notify_all`]: Self::notify_all
+    #[inline]
+    pub fn notify_one(&self) -> bool {
+        let runtime = current_runtime().unwrap();
+
+        runtime.enter_scheduler(|s, _| {
+            let task_woken = unsafe {
+                s.notify_one(self.raw.as_raw(), crate::raw::WakeupData::None)
+                    .expect("could not wake task")
+            };
+
+            // If there are no more waiting tasks we clear the mutex state.
+            if let Some(remaining) = task_woken {
+                if remaining == 0 {
+                    self.state
+                        .store(std::ptr::null_mut(), atomic::Ordering::Release);
+                }
+                true
+            } else {
+                false
+            }
+        })
+    }
+
+    /// Wakes up all blocked task on this condvar.
+    ///
+    /// Returns the number of threads woken up.
+    ///
+    /// This method will ensure that any current waiters on the condition
+    /// variable are awoken. Calls to `notify_all()` are not buffered in any
+    /// way.
+    ///
+    /// To wake up only one thread, see [`notify_one`].
+    ///
+    /// [`notify_one`]: Self::notify_one
+    #[inline]
+    pub fn notify_all(&self) -> usize {
+        let runtime = current_runtime().unwrap();
+
+        runtime.enter_scheduler(|s, _| {
+            let num = unsafe {
+                s.notify_all(self.raw.as_raw(), crate::raw::WakeupData::None)
+                    .expect("could not wake task")
+            };
+
+            // Cleanup the local state.
+            self.state
+                .store(std::ptr::null_mut(), atomic::Ordering::Release);
+
+            num
+        })
+    }
+}
+
+unsafe impl Send for Condvar {}
+unsafe impl Sync for Condvar {}
+
+impl Default for Condvar {
+    #[inline]
+    fn default() -> Self {
+        Condvar::new()
+    }
+}
+
+impl Debug for Condvar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Condvar").finish_non_exhaustive()
+    }
+}
+
+impl Drop for Condvar {
+    fn drop(&mut self) {
+        self.raw
+            .unblock()
+            .expect("could not unblock the condvar task")
+    }
+}

--- a/interfaces/fimo_tasks_int/src/sync/mutex.rs
+++ b/interfaces/fimo_tasks_int/src/sync/mutex.rs
@@ -17,7 +17,7 @@ use rand::SeedableRng;
 
 /// A mutual exclusion primitive useful for protecting shared data
 ///
-/// This mutex will block threads waiting for the lock to become available. The
+/// This mutex will block tasks waiting for the lock to become available. The
 /// mutex can also be statically initialized or created via a [`new`]
 /// constructor. Each mutex has a type parameter which represents the data that
 /// it is protecting. The data can only be accessed through the RAII guards

--- a/interfaces/fimo_tasks_int/src/sync/mutex.rs
+++ b/interfaces/fimo_tasks_int/src/sync/mutex.rs
@@ -249,7 +249,7 @@ impl RawMutex {
     const WAITERS_BIT: u8 = 0b10;
 
     const UNINIT_TOKEN: *const () = std::ptr::null();
-    const HANDOFF_LOCK: *const () = 1 as *const ();
+    const HANDOFF_LOCK: *const () = std::ptr::invalid(1);
 
     #[inline]
     fn new() -> Self {

--- a/interfaces/fimo_tasks_int/src/sync/mutex.rs
+++ b/interfaces/fimo_tasks_int/src/sync/mutex.rs
@@ -333,8 +333,7 @@ impl RawMutex {
                             .expect("can not create mutex task");
 
                         // Try to wait on the task.
-                        match s.pseudo_wait_task_on(curr, task, Some(&mut data), WaitToken::INVALID)
-                        {
+                        match s.wait_task_on(curr, task, Some(&mut data), WaitToken::INVALID) {
                             Ok(_) => (),
                             Err(_) => {
                                 // If we could not wait we must check whether the mutex has other
@@ -508,9 +507,7 @@ impl RawMutex {
             let mut callback = MaybeUninit::new(callback);
             let callback = FfiFn::new_value(&mut callback);
 
-            let res = s
-                .pseudo_notify_one(task, callback)
-                .expect("could not wake task");
+            let res = s.notify_one(task, callback).expect("could not wake task");
 
             if !res.has_tasks_remaining() {
                 // If there are no more waiters we unregister the task.

--- a/interfaces/fimo_tasks_int/src/sync/mutex.rs
+++ b/interfaces/fimo_tasks_int/src/sync/mutex.rs
@@ -1,0 +1,484 @@
+use std::{
+    cell::{Cell, UnsafeCell},
+    fmt::{Debug, Display},
+    mem::{ManuallyDrop, MaybeUninit},
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    sync::atomic::AtomicU8,
+    time::{Duration, Instant},
+};
+
+use crate::{
+    raw::WakeupData,
+    runtime::{current_runtime, IRuntimeExt, IScheduler},
+};
+use crate::{
+    sync::spin_wait::SpinWait,
+    task::{Builder, JoinHandle, Task},
+};
+use fimo_ffi::ObjBox;
+use rand::SeedableRng;
+
+/// A mutual exclusion primitive useful for protecting shared data
+///
+/// This mutex will block threads waiting for the lock to become available. The
+/// mutex can also be statically initialized or created via a [`new`]
+/// constructor. Each mutex has a type parameter which represents the data that
+/// it is protecting. The data can only be accessed through the RAII guards
+/// returned from [`lock`] and [`try_lock`], which guarantees that the data is only
+/// ever accessed when the mutex is locked.
+///
+/// [`new`]: Mutex::new
+/// [`lock`]: Mutex::lock
+/// [`try_lock`]: Mutex::try_lock
+pub struct Mutex<T: ?Sized> {
+    raw: RawMutex,
+    data: UnsafeCell<T>,
+}
+
+impl<T> Mutex<T> {
+    /// Creates a new mutex in an unlocked state ready for use.
+    #[inline]
+    pub fn new(val: T) -> Self {
+        Self {
+            raw: RawMutex::new(),
+            data: UnsafeCell::new(val),
+        }
+    }
+
+    /// Consumes this mutex, returning the underlying data.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.data.into_inner()
+    }
+}
+
+impl<T: ?Sized> Mutex<T> {
+    /// Acquires a mutex, blocking the current task until it is able to do so.
+    ///
+    /// This function will block the local task until it is available to acquire
+    /// the mutex. Upon returning, the task is the only task with the lock
+    /// held. An RAII guard is returned to allow scoped unlock of the lock. When
+    /// the guard goes out of scope, the mutex will be unlocked.
+    ///
+    /// The exact behavior on locking a mutex in the task which already holds
+    /// the lock is left unspecified. However, this function will not return on
+    /// the second call (it might panic or deadlock, for example).
+    #[inline]
+    pub fn lock(&self) -> MutexGuard<'_, T> {
+        self.raw.lock();
+        MutexGuard { lock: self }
+    }
+
+    /// Attempts to acquire this lock.
+    ///
+    /// If the lock could not be acquired at this time, then [`None`] is returned.
+    /// Otherwise, an RAII guard is returned. The lock will be unlocked when the
+    /// guard is dropped.
+    ///
+    /// This function does not block.
+    #[inline]
+    pub fn try_lock(&self) -> Option<MutexGuard<'_, T>> {
+        if self.raw.try_lock() {
+            Some(MutexGuard { lock: self })
+        } else {
+            None
+        }
+    }
+
+    /// Immediately drops the guard, and consequently unlocks the mutex.
+    ///
+    /// This function is equivalent to calling [`drop`] on the guard but is more self-documenting.
+    /// Alternately, the guard will be automatically dropped when it goes out of scope.
+    #[inline]
+    pub fn unlock(guard: MutexGuard<'_, T>) {
+        drop(guard)
+    }
+
+    /// Immediately drops the guard, and consequently unlocks the mutex.
+    ///
+    /// This function is equivalent to calling [`unlock_fair`](MutexGuard::unlock_fair)
+    /// on the guard. Alternately, the guard will be automatically dropped when it goes out of
+    /// scope, but will use the standard unlocking mechanism.
+    #[inline]
+    pub fn unlock_fair(guard: MutexGuard<'_, T>) {
+        guard.unlock_fair()
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `Mutex` mutably, no actual locking needs to
+    /// take place -- the mutable borrow statically guarantees no locks exist.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.data.get_mut()
+    }
+}
+
+unsafe impl<T: Send + ?Sized> Send for Mutex<T> {}
+unsafe impl<T: Send + ?Sized> Sync for Mutex<T> {}
+
+impl<T: Debug + ?Sized> Debug for Mutex<T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        let mut d = f.debug_struct("Mutex");
+
+        match self.try_lock() {
+            Some(guard) => {
+                d.field("data", &&*guard);
+            }
+            None => {
+                struct LockedPlaceholder;
+                impl Debug for LockedPlaceholder {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        f.write_str("<locked>")
+                    }
+                }
+                d.field("data", &LockedPlaceholder);
+            }
+        }
+
+        d.finish()
+    }
+}
+
+impl<T: Default + ?Sized> Default for Mutex<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<T> From<T> for Mutex<T> {
+    #[inline]
+    fn from(val: T) -> Self {
+        Self::new(val)
+    }
+}
+
+/// An RAII implementation of a "scoped lock" of a mutex. When this structure is
+/// dropped (falls out of scope), the lock will be unlocked.
+///
+/// The data protected by the mutex can be accessed through this guard via its
+/// [`Deref`] and [`DerefMut`] implementations.
+///
+/// This structure is created by the [`lock`] and [`try_lock`] methods on
+/// [`Mutex`].
+///
+/// [`lock`]: Mutex::lock
+/// [`try_lock`]: Mutex::try_lock
+#[must_use = "if unused the Mutex will immediately unlock"]
+pub struct MutexGuard<'a, T: ?Sized> {
+    lock: &'a Mutex<T>,
+}
+
+impl<T: ?Sized> MutexGuard<'_, T> {
+    /// Unlocks the mutex using a fair unlock protocol.
+    #[inline]
+    pub fn unlock_fair(self) {
+        // SAFETY: We know that we own a lock.
+        let m = ManuallyDrop::new(self);
+        unsafe { m.lock.raw.unlock_fair() }
+    }
+}
+
+impl<T: ?Sized> !Send for MutexGuard<'_, T> {}
+unsafe impl<T: Sync + ?Sized> Sync for MutexGuard<'_, T> {}
+
+impl<T: ?Sized> Deref for MutexGuard<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        // SAFETY: We are the sole owners of the data until the lock
+        // is dropped.
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for MutexGuard<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // SAFETY: We are the sole owners of the data until the lock
+        // is dropped.
+        unsafe { &mut *self.lock.data.get() }
+    }
+}
+
+impl<T: Debug + ?Sized> Debug for MutexGuard<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: Display + ?Sized> Display for MutexGuard<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized> Drop for MutexGuard<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: We know that we own a lock.
+        unsafe { self.lock.raw.unlock() }
+    }
+}
+
+// Based on the implementation in the parking_lot crate.
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+struct RawMutex {
+    state: AtomicU8,
+    fair_timeout: Cell<Instant>,
+    rng: UnsafeCell<rand::rngs::SmallRng>,
+    task: JoinHandle<Pin<ObjBox<Task<'static, ()>>>>,
+}
+
+impl RawMutex {
+    const STATE_INIT: u8 = 0;
+
+    const LOCKED_BIT: u8 = 0b01;
+    const WAITERS_BIT: u8 = 0b10;
+
+    const HANDOFF_LOCK: *const () = 1 as *const ();
+
+    #[inline]
+    fn new() -> Self {
+        let runtime = current_runtime().unwrap();
+
+        let task = Builder::new()
+            .blocked()
+            .spawn_complex::<_, fn(), _, fn()>(runtime, None, None, &[])
+            .expect("could not create mutex task");
+
+        let rng = rand::rngs::SmallRng::from_entropy();
+
+        Self {
+            task,
+            rng: UnsafeCell::new(rng),
+            state: AtomicU8::new(Self::STATE_INIT),
+            fair_timeout: Cell::new(Instant::now()),
+        }
+    }
+
+    #[inline]
+    fn lock(&self) {
+        // Try to acquire the lock by performing a CAS operation on the state.
+        // The `Acquire` synchronizes with the `Release` in unlock and unlock_fair.
+        if self
+            .state
+            .compare_exchange_weak(
+                Self::STATE_INIT,
+                Self::LOCKED_BIT,
+                atomic::Ordering::Acquire,
+                atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            self.lock_slow()
+        }
+    }
+
+    #[inline]
+    fn lock_slow(&self) {
+        let runtime = current_runtime().unwrap();
+        let mut spinwait = SpinWait::new();
+        let mut state = self.state.load(atomic::Ordering::Relaxed);
+        loop {
+            // Grab the lock if it isn't locked, even if there is a queue on it
+            if state & Self::LOCKED_BIT == 0 {
+                match self.state.compare_exchange_weak(
+                    state,
+                    state | Self::LOCKED_BIT,
+                    atomic::Ordering::Acquire,
+                    atomic::Ordering::Relaxed,
+                ) {
+                    Ok(_) => return,
+                    Err(x) => state = x,
+                }
+                continue;
+            }
+
+            // If there is no queue, try spinning a few times
+            if state & Self::WAITERS_BIT == 0 && spinwait.spin(|| runtime.yield_now()) {
+                state = self.state.load(atomic::Ordering::Relaxed);
+                continue;
+            }
+
+            // Set the parked bit
+            if state & Self::WAITERS_BIT == 0 {
+                if let Err(x) = self.state.compare_exchange_weak(
+                    state,
+                    state | Self::WAITERS_BIT,
+                    atomic::Ordering::Relaxed,
+                    atomic::Ordering::Relaxed,
+                ) {
+                    state = x;
+                    continue;
+                }
+            }
+
+            // Block our tasks until we are woken up by an unlock
+            let mut data = MaybeUninit::uninit();
+            runtime.yield_and_enter(|s, curr| {
+                let state = self.state.load(atomic::Ordering::Relaxed);
+                if state == Self::LOCKED_BIT | Self::WAITERS_BIT {
+                    unsafe {
+                        s.wait_task_on(curr, self.task.as_raw(), Some(&mut data))
+                            .expect("can not wait on mutex");
+                    }
+                }
+            });
+
+            // SAFETY: We were woken up by the runtime, so the data must contain some valid message.
+            match unsafe { data.assume_init() } {
+                // Normal wakeup, retry.
+                WakeupData::None => (),
+
+                // Handoff, we now own the lock.
+                WakeupData::Custom(Self::HANDOFF_LOCK) => return,
+
+                // Internal error.
+                WakeupData::Custom(_) => unreachable!(),
+            }
+
+            // Loop back and try locking again
+            spinwait.reset();
+            state = self.state.load(atomic::Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    fn try_lock(&self) -> bool {
+        // Relaxed is sufficient, as the CAS-loop ensures that we eventually land
+        // with the correct state.
+        let mut state = self.state.load(atomic::Ordering::Relaxed);
+        loop {
+            // If the locked bit is set we know that the mutex is locked and return false.
+            if state & Self::LOCKED_BIT != 0 {
+                return false;
+            }
+
+            // The `Acquire` synchronizes with the `Release` in unlock and unlock_fair.
+            match self.state.compare_exchange_weak(
+                state,
+                state | Self::LOCKED_BIT,
+                atomic::Ordering::Acquire,
+                atomic::Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(x) => state = x,
+            }
+        }
+    }
+
+    #[inline]
+    unsafe fn unlock(&self) {
+        if self
+            .state
+            .compare_exchange_weak(
+                Self::LOCKED_BIT,
+                Self::STATE_INIT,
+                atomic::Ordering::Release,
+                atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            self.unlock_slow(false)
+        }
+    }
+
+    #[inline]
+    unsafe fn unlock_fair(&self) {
+        if self
+            .state
+            .compare_exchange_weak(
+                Self::LOCKED_BIT,
+                Self::STATE_INIT,
+                atomic::Ordering::Release,
+                atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            self.unlock_slow(true)
+        }
+    }
+
+    #[inline]
+    fn use_fair_unlock(&self) -> bool {
+        use rand::Rng;
+
+        let now = Instant::now();
+        if now > self.fair_timeout.get() {
+            let rng = self.rng.get();
+
+            // Time between 0 and 1ms.
+            // SAFETY: Is only used while the scheduler is locked.
+            let nanos = unsafe { (*rng).gen_range(0..1_000_000) };
+            self.fair_timeout.set(now + Duration::new(0, nanos));
+
+            true
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    unsafe fn unlock_slow(&self, fair: bool) {
+        let runtime = current_runtime().unwrap();
+
+        // The slow path uses the runtime the synchronize and wake sleeping
+        // tasks.
+        runtime.enter_scheduler(move |s, _| {
+            let num_waiters = s.num_waiting_tasks(self.task.as_raw());
+            let one_waiter = num_waiters == 1;
+            let has_waiters = num_waiters != 0;
+
+            // If we are using a fair unlock then we simply hand the ownership of the lock
+            // to the newly woken up task.
+            if has_waiters && (fair || self.use_fair_unlock()) {
+                let data = WakeupData::Custom(Self::HANDOFF_LOCK);
+                s.notify_one(self.task.as_raw(), data)
+                    .expect("could not wake task");
+
+                // Clear the waiters bit if there are no more waiting tasks.
+                if one_waiter {
+                    self.state
+                        .store(Self::LOCKED_BIT, atomic::Ordering::Relaxed)
+                }
+                return;
+            }
+
+            let num_waiters = s
+                .notify_one(self.task.as_raw(), WakeupData::None)
+                .expect("could not wake task")
+                .unwrap_or(0);
+
+            if num_waiters != 0 {
+                // If there are still waiters we only remove the locked bit.
+                self.state
+                    .store(Self::WAITERS_BIT, atomic::Ordering::Release)
+            } else {
+                // If there are no more waiters we set the state to the initial value.
+                self.state
+                    .store(Self::STATE_INIT, atomic::Ordering::Release)
+            }
+        });
+    }
+}
+
+unsafe impl Send for RawMutex {}
+unsafe impl Sync for RawMutex {}
+
+impl Drop for RawMutex {
+    fn drop(&mut self) {
+        self.task.unblock().expect("could not unblock mutex task")
+    }
+}

--- a/interfaces/fimo_tasks_int/src/sync/rwlock.rs
+++ b/interfaces/fimo_tasks_int/src/sync/rwlock.rs
@@ -1,0 +1,917 @@
+use std::{
+    cell::{Cell, UnsafeCell},
+    fmt::{Debug, Display},
+    mem::{ManuallyDrop, MaybeUninit},
+    ops::{Deref, DerefMut},
+    sync::atomic::AtomicUsize,
+    time::{Duration, Instant},
+};
+
+use fimo_ffi::FfiFn;
+use rand::SeedableRng;
+
+use crate::runtime::{
+    current_runtime, IRuntimeExt, IScheduler, NotifyFilterOp, NotifyResult, WaitToken, WakeupToken,
+};
+
+use super::spin_wait::SpinWait;
+
+/// A reader-writer lock
+///
+/// This type of lock allows a number of readers or at most one writer at any
+/// point in time. The write portion of this lock typically allows modification
+/// of the underlying data (exclusive access) and the read portion of this lock
+/// typically allows for read-only access (shared access).
+///
+/// In comparison, a [`Mutex`] does not distinguish between readers or writers
+/// that acquire the lock, therefore blocking any tasks waiting for the lock to
+/// become available. An `RwLock` will allow any number of readers to acquire the
+/// lock as long as a writer is not holding the lock.
+///
+/// This lock uses a task-fair locking policy which avoids both reader and
+/// writer starvation. This means that readers trying to acquire the lock will
+/// block even if the lock is unlocked when there are writers waiting to acquire
+/// the lock. Because of this, attempts to recursively acquire a read lock
+/// within a single task may result in a deadlock.
+///
+/// The type parameter `T` represents the data that this lock protects. It is
+/// required that `T` satisfies [`Send`] to be shared across tasks and
+/// [`Sync`] to allow concurrent access through readers. The RAII guards
+/// returned from the locking methods implement [`Deref`] (and [`DerefMut`]
+/// for the `write` methods) to allow access to the content of the lock.
+///
+/// [`Mutex`]: super::Mutex
+pub struct RwLock<T: ?Sized> {
+    raw: RawRwLock,
+    data: UnsafeCell<T>,
+}
+
+impl<T> RwLock<T> {
+    /// Creates a new instance of an `RwLock<T>` which is unlocked.
+    #[inline]
+    pub fn new(t: T) -> RwLock<T> {
+        Self {
+            raw: RawRwLock::new(),
+            data: UnsafeCell::new(t),
+        }
+    }
+
+    /// Consumes this `RwLock`, returning the underlying data.
+    #[inline]
+    pub fn into_inner(self) -> T {
+        self.data.into_inner()
+    }
+}
+
+impl<T: ?Sized> RwLock<T> {
+    /// Locks this rwlock with shared read access, blocking the current task
+    /// until it can be acquired.
+    ///
+    /// The calling task will be blocked until there are no more writers which
+    /// hold the lock. There may be other readers currently inside the lock when
+    /// this method returns.
+    ///
+    /// Returns an RAII guard which will release this task's shared access
+    /// once it is dropped.
+    ///
+    /// # Panics
+    ///
+    /// This function might panic when called if the lock is already held by the current task.
+    #[inline]
+    pub fn read(&self) -> RwLockReadGuard<'_, T> {
+        self.raw.lock_read();
+        RwLockReadGuard { lock: self }
+    }
+
+    /// Attempts to acquire this rwlock with shared read access.
+    ///
+    /// If the access could not be granted at this time, then `None` is returned.
+    /// Otherwise, an RAII guard is returned which will release the shared access
+    /// when it is dropped.
+    ///
+    /// This function does not block.
+    #[inline]
+    pub fn try_read(&self) -> Option<RwLockReadGuard<'_, T>> {
+        if self.raw.try_lock_read() {
+            Some(RwLockReadGuard { lock: self })
+        } else {
+            None
+        }
+    }
+
+    /// Locks this rwlock with exclusive write access, blocking the current
+    /// task until it can be acquired.
+    ///
+    /// This function will not return while other writers or other readers
+    /// currently have access to the lock.
+    ///
+    /// Returns an RAII guard which will drop the write access of this rwlock
+    /// when dropped.
+    #[inline]
+    pub fn write(&self) -> RwLockWriteGuard<'_, T> {
+        self.raw.lock_write();
+        RwLockWriteGuard { lock: self }
+    }
+
+    /// Attempts to lock this rwlock with exclusive write access.
+    ///
+    /// If the lock could not be acquired at this time, then `None` is returned.
+    /// Otherwise, an RAII guard is returned which will release the lock when
+    /// it is dropped.
+    ///
+    /// This function does not block.
+    #[inline]
+    pub fn try_write(&self) -> Option<RwLockWriteGuard<'_, T>> {
+        if self.raw.try_lock_write() {
+            Some(RwLockWriteGuard { lock: self })
+        } else {
+            None
+        }
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    ///
+    /// Since this call borrows the `RwLock` mutably, no actual locking needs to
+    /// take place -- the mutable borrow statically guarantees no locks exist.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut T {
+        self.data.get_mut()
+    }
+
+    /// Checks whether this `RwLock` is currently locked in any way.
+    #[inline]
+    pub fn is_locked(&self) -> bool {
+        self.raw.is_locked()
+    }
+
+    /// Check if this `RwLock` is currently exclusively locked.
+    #[inline]
+    pub fn is_locked_exclusive(&self) -> bool {
+        self.raw.is_locked_exclusive()
+    }
+}
+
+unsafe impl<T: Send + ?Sized> Send for RwLock<T> {}
+unsafe impl<T: Send + Sync + ?Sized> Sync for RwLock<T> {}
+
+impl<T: Default> Default for RwLock<T> {
+    #[inline]
+    fn default() -> Self {
+        Self::new(Default::default())
+    }
+}
+
+impl<T: Debug + ?Sized> Debug for RwLock<T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut d = f.debug_struct("RwLock");
+        match self.try_read() {
+            Some(guard) => {
+                d.field("data", &&*guard);
+            }
+            None => {
+                struct LockedPlaceholder;
+                impl Debug for LockedPlaceholder {
+                    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                        f.write_str("<locked>")
+                    }
+                }
+                d.field("data", &LockedPlaceholder);
+            }
+        }
+        d.finish()
+    }
+}
+
+impl<T> From<T> for RwLock<T> {
+    #[inline]
+    fn from(t: T) -> Self {
+        Self::new(t)
+    }
+}
+
+/// RAII structure used to release the shared read access of a lock when
+/// dropped.
+///
+/// This structure is created by the [`read`] and [`try_read`] methods on
+/// [`RwLock`].
+///
+/// [`read`]: RwLock::read
+/// [`try_read`]: RwLock::try_read
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct RwLockReadGuard<'a, T: ?Sized> {
+    lock: &'a RwLock<T>,
+}
+
+impl<T: ?Sized> RwLockReadGuard<'_, T> {
+    /// Unlocks the `RwLock`.
+    ///
+    /// Convenience function for `drop(self)`.
+    #[inline]
+    pub fn unlock(self) {
+        drop(self)
+    }
+
+    /// Unlocks the `RwLock` using a fair unlock protocol.
+    #[inline]
+    pub fn unlock_fair(self) {
+        // SAFETY: We know that we own a lock.
+        let this = ManuallyDrop::new(self);
+        unsafe { this.lock.raw.unlock_read_fair() }
+    }
+}
+
+impl<T: ?Sized> !Send for RwLockReadGuard<'_, T> {}
+unsafe impl<T: Sync + ?Sized> Sync for RwLockReadGuard<'_, T> {}
+
+impl<T: ?Sized> Deref for RwLockReadGuard<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T: Debug> Debug for RwLockReadGuard<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: Display + ?Sized> Display for RwLockReadGuard<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized> Drop for RwLockReadGuard<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: We own a read lock.
+        unsafe { self.lock.raw.unlock_read() }
+    }
+}
+
+/// RAII structure used to release the exclusive write access of a lock when
+/// dropped.
+///
+/// This structure is created by the [`write`] and [`try_write`] methods
+/// on [`RwLock`].
+///
+/// [`write`]: RwLock::write
+/// [`try_write`]: RwLock::try_write
+#[must_use = "if unused the RwLock will immediately unlock"]
+pub struct RwLockWriteGuard<'a, T: ?Sized> {
+    lock: &'a RwLock<T>,
+}
+
+impl<T: ?Sized> RwLockWriteGuard<'_, T> {
+    /// Unlocks the `RwLock`.
+    ///
+    /// Convenience function for `drop(self)`.
+    #[inline]
+    pub fn unlock(self) {
+        drop(self)
+    }
+
+    /// Unlocks the `RwLock` using a fair unlock protocol.
+    #[inline]
+    pub fn unlock_fair(self) {
+        // SAFETY: We know that we own a lock.
+        let this = ManuallyDrop::new(self);
+        unsafe { this.lock.raw.unlock_write_fair() }
+    }
+}
+
+impl<T: ?Sized> !Send for RwLockWriteGuard<'_, T> {}
+unsafe impl<T: Sync + ?Sized> Sync for RwLockWriteGuard<'_, T> {}
+
+impl<T: ?Sized> Deref for RwLockWriteGuard<'_, T> {
+    type Target = T;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.lock.data.get() }
+    }
+}
+
+impl<T: ?Sized> DerefMut for RwLockWriteGuard<'_, T> {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.lock.data.get() }
+    }
+}
+
+impl<T: Debug> Debug for RwLockWriteGuard<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(&**self, f)
+    }
+}
+
+impl<T: Display + ?Sized> Display for RwLockWriteGuard<'_, T> {
+    #[inline]
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(&**self, f)
+    }
+}
+
+impl<T: ?Sized> Drop for RwLockWriteGuard<'_, T> {
+    #[inline]
+    fn drop(&mut self) {
+        // SAFETY: We own the write lock.
+        unsafe { self.lock.raw.unlock_write() }
+    }
+}
+
+// Based on the implementation in the parking_lot crate.
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+struct RawRwLock {
+    state: AtomicUsize,
+    fair_timeout: Cell<Instant>,
+    rng: UnsafeCell<rand::rngs::SmallRng>,
+}
+
+impl RawRwLock {
+    const STATE_INIT: usize = 0;
+
+    const UNINIT_TOKEN: *const () = std::ptr::null();
+    const HANDOFF_LOCK: *const () = std::ptr::invalid(1);
+
+    // There is at least one task in the main queue.
+    const WAITING_BIT: usize = 0b0001;
+    // There is a waiting task holding WRITER_BIT. WRITER_BIT must be set.
+    const WRITER_WAITING_BIT: usize = 0b0010;
+    // If the reader count is zero: a writer is currently holding an exclusive lock.
+    // Otherwise: a writer is waiting for the remaining readers to exit the lock.
+    const WRITER_BIT: usize = 0b1000;
+    // Mask of bits used to count readers.
+    const READERS_MASK: usize = !0b1111;
+    // Base unit for counting readers.
+    const ONE_READER: usize = 0b10000;
+
+    // Token indicating what type of lock a queued task is trying to acquire
+    const TOKEN_SHARED: WaitToken = WaitToken(std::ptr::invalid(Self::ONE_READER));
+    const TOKEN_EXCLUSIVE: WaitToken = WaitToken(std::ptr::invalid(Self::WRITER_BIT));
+
+    #[inline]
+    fn new() -> Self {
+        let rng = rand::rngs::SmallRng::from_entropy();
+
+        Self {
+            rng: UnsafeCell::new(rng),
+            state: AtomicUsize::new(Self::STATE_INIT),
+            fair_timeout: Cell::new(Instant::now()),
+        }
+    }
+
+    #[inline]
+    fn is_locked(&self) -> bool {
+        let state = self.state.load(atomic::Ordering::Relaxed);
+        state & (Self::WRITER_BIT | Self::READERS_MASK) != 0
+    }
+
+    #[inline]
+    fn is_locked_exclusive(&self) -> bool {
+        let state = self.state.load(atomic::Ordering::Relaxed);
+        state & (Self::WRITER_BIT) != 0
+    }
+
+    #[inline]
+    fn lock_write(&self) {
+        if self
+            .state
+            .compare_exchange_weak(
+                Self::STATE_INIT,
+                Self::WRITER_BIT,
+                atomic::Ordering::Acquire,
+                atomic::Ordering::Relaxed,
+            )
+            .is_err()
+        {
+            self.lock_write_slow()
+        }
+    }
+
+    #[inline]
+    fn try_lock_write(&self) -> bool {
+        self.state
+            .compare_exchange(
+                Self::STATE_INIT,
+                Self::WRITER_BIT,
+                atomic::Ordering::Acquire,
+                atomic::Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    #[inline]
+    unsafe fn unlock_write(&self) {
+        if self
+            .state
+            .compare_exchange(
+                Self::WRITER_BIT,
+                Self::STATE_INIT,
+                atomic::Ordering::Release,
+                atomic::Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            return;
+        }
+        self.unlock_write_slow(false);
+    }
+
+    #[inline]
+    unsafe fn unlock_write_fair(&self) {
+        if self
+            .state
+            .compare_exchange(
+                Self::WRITER_BIT,
+                Self::STATE_INIT,
+                atomic::Ordering::Release,
+                atomic::Ordering::Relaxed,
+            )
+            .is_ok()
+        {
+            return;
+        }
+        self.unlock_write_slow(true);
+    }
+
+    #[inline]
+    fn lock_read(&self) {
+        if !self.try_lock_read_fast() {
+            self.lock_read_slow();
+        }
+    }
+
+    #[inline]
+    fn try_lock_read(&self) -> bool {
+        if self.try_lock_read_fast() {
+            true
+        } else {
+            self.try_lock_read_slow()
+        }
+    }
+
+    #[inline]
+    unsafe fn unlock_read(&self) {
+        let state = self
+            .state
+            .fetch_sub(Self::ONE_READER, atomic::Ordering::Release);
+
+        if state & (Self::READERS_MASK | Self::WRITER_WAITING_BIT)
+            == (Self::ONE_READER | Self::WRITER_WAITING_BIT)
+        {
+            self.unlock_read_slow();
+        }
+    }
+
+    #[inline]
+    unsafe fn unlock_read_fair(&self) {
+        // Shared unlocking is always fair in this implementation.
+        self.unlock_read();
+    }
+}
+
+impl RawRwLock {
+    #[cold]
+    fn lock_write_slow(&self) {
+        let try_lock = |state: &mut usize| {
+            loop {
+                if *state & Self::WRITER_BIT != 0 {
+                    return false;
+                }
+
+                // Grab WRITER_BIT if it isn't set, even if there are waiting tasks.
+                match self.state.compare_exchange_weak(
+                    *state,
+                    *state | Self::WRITER_BIT,
+                    atomic::Ordering::Acquire,
+                    atomic::Ordering::Relaxed,
+                ) {
+                    Ok(_) => return true,
+                    Err(x) => *state = x,
+                }
+            }
+        };
+
+        // Step 1: grab exclusive ownership of WRITER_BIT
+        self.lock_common(Self::TOKEN_EXCLUSIVE, try_lock, Self::WRITER_BIT);
+
+        // Step 2: wait for all remaining readers to exit the lock.
+        self.wait_for_readers()
+    }
+
+    #[cold]
+    fn unlock_write_slow(&self, force_fair: bool) {
+        // There are tasks to unpark. Try to unpark as many as we can.
+        let callback = |mut new_state, result: NotifyResult| {
+            // If we are using a fair unlock then we should keep the
+            // rwlock locked and hand it off to the notified tasks.
+            if result.has_notified_tasks() && (force_fair || self.use_fair_unlock()) {
+                if result.has_tasks_remaining() {
+                    new_state |= Self::WAITING_BIT;
+                }
+                self.state.store(new_state, atomic::Ordering::Release);
+                WakeupToken::Custom(Self::HANDOFF_LOCK)
+            } else {
+                // Clear the waiting bit if there are no more waiting tasks.
+                if result.has_tasks_remaining() {
+                    self.state
+                        .store(Self::WAITING_BIT, atomic::Ordering::Release);
+                } else {
+                    self.state.store(0, atomic::Ordering::Release);
+                }
+                WakeupToken::None
+            }
+        };
+
+        // SAFETY: `callback` does not panic or call into the scheduler.
+        unsafe { self.wake_parked_tasks(0, callback) };
+    }
+
+    #[cold]
+    fn lock_read_slow(&self) {
+        let try_lock = |state: &mut usize| {
+            let mut spinwait_shared = SpinWait::new();
+            loop {
+                // This is the same condition as try_lock_shared_fast
+                if *state & Self::WRITER_BIT != 0 {
+                    return false;
+                }
+
+                if self
+                    .state
+                    .compare_exchange_weak(
+                        *state,
+                        state
+                            .checked_add(Self::ONE_READER)
+                            .expect("RwLock reader count overflow"),
+                        atomic::Ordering::Acquire,
+                        atomic::Ordering::Relaxed,
+                    )
+                    .is_ok()
+                {
+                    return true;
+                }
+
+                // If there is high contention on the reader count then we want
+                // to leave some time between attempts to acquire the lock to
+                // let other tasks make progress.
+                spinwait_shared.spin(|| {});
+                *state = self.state.load(atomic::Ordering::Relaxed);
+            }
+        };
+        self.lock_common(Self::TOKEN_SHARED, try_lock, Self::WRITER_BIT)
+    }
+
+    #[cold]
+    fn unlock_read_slow(&self) {
+        // At this point WRITER_WAITING_BIT is set and READER_MASK is empty. We
+        // just need to wake up a potentially sleeping pending writer.
+        // Using the 2nd key at addr + 1
+        let runtime = current_runtime().unwrap();
+        runtime.enter_scheduler(|s, _| unsafe {
+            let queue_addr = (self as *const RawRwLock).addr() + 1;
+            let queue_addr = (self as *const _ as *const ()).with_addr(queue_addr);
+            let queue = s
+                .register_or_fetch_pseudo_task(queue_addr)
+                .expect("could not fetch rwlock queue task");
+
+            let callback = |_| {
+                // Clear the WRITER_WAITING_BIT here since there can only be one
+                // waiting writer task.
+                self.state
+                    .fetch_and(!Self::WRITER_WAITING_BIT, atomic::Ordering::Relaxed);
+                WakeupToken::None
+            };
+            let mut callback = MaybeUninit::new(callback);
+            let callback = FfiFn::new_value(&mut callback);
+
+            let res = s
+                .pseudo_notify_one(queue, callback)
+                .expect("could not wake task");
+
+            if !res.has_tasks_remaining() {
+                // If there are no more waiters we unregister the task.
+                s.unregister_pseudo_task(queue)
+                    .expect("could not unregister rwlock queue task")
+            }
+        });
+    }
+
+    #[inline(always)]
+    fn try_lock_read_fast(&self) -> bool {
+        let state = self.state.load(atomic::Ordering::Relaxed);
+
+        // We can't allow grabbing a shared lock if there is a writer, even if
+        // the writer is still waiting for the remaining readers to exit.
+        if state & Self::WRITER_BIT != 0 {
+            return false;
+        }
+
+        if let Some(new_state) = state.checked_add(Self::ONE_READER) {
+            self.state
+                .compare_exchange_weak(
+                    state,
+                    new_state,
+                    atomic::Ordering::Acquire,
+                    atomic::Ordering::Relaxed,
+                )
+                .is_ok()
+        } else {
+            false
+        }
+    }
+
+    #[cold]
+    fn try_lock_read_slow(&self) -> bool {
+        let mut state = self.state.load(atomic::Ordering::Relaxed);
+        loop {
+            // This mirrors the condition in try_lock_shared_fast
+            if state & Self::WRITER_BIT != 0 {
+                return false;
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state
+                    .checked_add(Self::ONE_READER)
+                    .expect("RwLock reader count overflow"),
+                atomic::Ordering::Acquire,
+                atomic::Ordering::Relaxed,
+            ) {
+                Ok(_) => return true,
+                Err(x) => state = x,
+            }
+        }
+    }
+
+    #[inline]
+    fn lock_common(
+        &self,
+        token: WaitToken,
+        mut try_lock: impl FnMut(&mut usize) -> bool,
+        validate_flags: usize,
+    ) {
+        let runtime = current_runtime().unwrap();
+        let mut spinwait = SpinWait::new();
+        let mut state = self.state.load(atomic::Ordering::Relaxed);
+        loop {
+            // Attempt to grab the lock
+            if try_lock(&mut state) {
+                return;
+            }
+
+            // If there are no waiting tasks, try spinning a few times.
+            if state & (Self::WAITING_BIT | Self::WRITER_WAITING_BIT) == 0
+                && spinwait.spin(|| runtime.yield_now())
+            {
+                state = self.state.load(atomic::Ordering::Relaxed);
+                continue;
+            }
+
+            // Set the waiting bit
+            if state & Self::WAITING_BIT == 0 {
+                if let Err(x) = self.state.compare_exchange_weak(
+                    state,
+                    state | Self::WAITING_BIT,
+                    atomic::Ordering::Relaxed,
+                    atomic::Ordering::Relaxed,
+                ) {
+                    state = x;
+                    continue;
+                }
+            }
+
+            // Park our task until we are woken up by an unlock
+            let mut data = MaybeUninit::new(WakeupToken::Custom(Self::UNINIT_TOKEN));
+            let waited = runtime.yield_and_enter(|s, curr| {
+                let state = self.state.load(atomic::Ordering::Relaxed);
+                if state & Self::WAITING_BIT != 0 && (state & validate_flags != 0) {
+                    unsafe {
+                        // SAFETY: We controll the address of the rwlock and it won't be moved until there are no more
+                        // tasks trying to lock it.
+                        let self_addr = self as *const _ as *const ();
+                        let task = s
+                            .register_or_fetch_pseudo_task(self_addr)
+                            .expect("can not create rwlock task");
+
+                        // Try to wait on the task.
+                        match s.pseudo_wait_task_on(curr, task, Some(&mut data), token) {
+                            Ok(_) => (),
+                            Err(_) => {
+                                // If we could not wait we must check whether the rwlock has other
+                                // waiters and deallocate it's task otherwise.
+                                assert!(s
+                                    .unregister_pseudo_task_if_empty(task)
+                                    .expect("could not unregister rwlock task"));
+                                panic!("can not wait on rwlock")
+                            }
+                        }
+                    }
+
+                    true
+                } else {
+                    false
+                }
+            });
+
+            if waited {
+                // SAFETY: We were woken up by the runtime, so the data must contain some valid message.
+                match unsafe { data.assume_init() } {
+                    // Normal wakeup, retry.
+                    WakeupToken::None => (),
+
+                    // Handoff, we now own the lock.
+                    WakeupToken::Custom(d) => {
+                        debug_assert_eq!(d, Self::HANDOFF_LOCK);
+                        return;
+                    }
+
+                    // Wait operation can never be skipped.
+                    WakeupToken::Skipped => unreachable!(),
+
+                    // Time out is not currently supported
+                    WakeupToken::TimedOut => panic!("RWLock time out not supported"),
+                }
+            }
+
+            // Loop back and try locking again
+            spinwait.reset();
+            state = self.state.load(atomic::Ordering::Relaxed);
+        }
+    }
+
+    // Common code for waiting for readers to exit the lock after acquiring
+    // WRITER_BIT.
+    #[inline]
+    fn wait_for_readers(&self) {
+        let runtime = current_runtime().unwrap();
+
+        // At this point WRITER_BIT is already set, we just need to wait for the
+        // remaining readers to exit the lock.
+        let mut spinwait = SpinWait::new();
+        let mut state = self.state.load(atomic::Ordering::Acquire);
+        while state & Self::READERS_MASK != 0 {
+            // Spin a few times to wait for readers to exit
+            if spinwait.spin(|| runtime.yield_now()) {
+                state = self.state.load(atomic::Ordering::Acquire);
+                continue;
+            }
+
+            // Set the waiting bit
+            if state & Self::WRITER_WAITING_BIT == 0 {
+                if let Err(x) = self.state.compare_exchange_weak(
+                    state,
+                    state | Self::WRITER_WAITING_BIT,
+                    atomic::Ordering::Relaxed,
+                    atomic::Ordering::Relaxed,
+                ) {
+                    state = x;
+                    continue;
+                }
+            }
+
+            // Park our task until we are woken up by an unlock
+            // Using the 2nd key at addr + 1
+            let mut data = MaybeUninit::new(WakeupToken::Custom(Self::UNINIT_TOKEN));
+            let waited = runtime.yield_and_enter(|s, curr| unsafe {
+                let state = self.state.load(atomic::Ordering::Relaxed);
+                if state & Self::READERS_MASK != 0 && state & Self::WRITER_WAITING_BIT != 0 {
+                    let queue_addr = (self as *const RawRwLock).addr() + 1;
+                    let queue_addr = (self as *const _ as *const ()).with_addr(queue_addr);
+                    let queue = s
+                        .register_or_fetch_pseudo_task(queue_addr)
+                        .expect("could not fetch rwlock queue task");
+
+                    // Try to wait on the task.
+                    match s.pseudo_wait_task_on(curr, queue, Some(&mut data), Self::TOKEN_EXCLUSIVE)
+                    {
+                        Ok(_) => (),
+                        Err(_) => {
+                            // If we could not wait we must check whether the queue has other
+                            // waiters and deallocate it's task otherwise.
+                            assert!(s
+                                .unregister_pseudo_task_if_empty(queue)
+                                .expect("could not unregister rwlock queue task"));
+                            panic!("can not wait on rwlock readers")
+                        }
+                    }
+
+                    true
+                } else {
+                    false
+                }
+            });
+
+            if waited {
+                // SAFETY: We were woken up by the runtime, so the data must contain some valid message.
+                match unsafe { data.assume_init() } {
+                    // We still need to re-check the state if we are notified
+                    // since a previous writer timing-out could have allowed
+                    // another reader to sneak in before we waited.
+                    //
+                    // Note: Not currently needed, will be required once we implement
+                    // time outs.
+                    WakeupToken::None | WakeupToken::Custom(_) => {
+                        state = self.state.load(atomic::Ordering::Acquire);
+                        continue;
+                    }
+
+                    // Wait operation can never be skipped.
+                    WakeupToken::Skipped => unreachable!(),
+
+                    // Time out is not currently supported
+                    WakeupToken::TimedOut => panic!("RwLock time out not supported"),
+                }
+            }
+        }
+    }
+
+    /// Common code for waking up waiting tasks after releasing WRITER_BIT.
+    ///
+    /// # Safety
+    ///
+    /// `callback` must uphold the requirements of the `callback` parameter to
+    /// `pseudo_notify_filter`. Meaning no panics or calls into any function in
+    /// the runtime.
+    unsafe fn wake_parked_tasks(
+        &self,
+        new_state: usize,
+        callback: impl FnOnce(usize, NotifyResult) -> WakeupToken,
+    ) {
+        // We must wake up at least one upgrader or writer if there is one,
+        // otherwise they may end up waiting indefinitely since unlock_read
+        // does not call wake_parked_tasks.
+        let new_state = Cell::new(new_state);
+        let filter = |WaitToken(token)| {
+            let s = new_state.get();
+
+            // If we are waking up a writer, don't wake anything else.
+            if s & Self::WRITER_BIT != 0 {
+                return NotifyFilterOp::Stop;
+            }
+
+            // Otherwise wake *all* readers and one upgrader/writer.
+            let token = token.addr();
+            new_state.set(s + token);
+            NotifyFilterOp::Notify
+        };
+        let mut filter = MaybeUninit::new(filter);
+        let filter = FfiFn::new_value(&mut filter);
+
+        let runtime = current_runtime().unwrap();
+        runtime.enter_scheduler(|s, _| {
+            let self_addr = self as *const _ as *const ();
+            let task = s
+                .register_or_fetch_pseudo_task(self_addr)
+                .expect("could not fetch rwlock task");
+
+            let callback = |result| callback(new_state.get(), result);
+            let mut callback = MaybeUninit::new(callback);
+            let callback = FfiFn::new_value(&mut callback);
+
+            let res = s
+                .pseudo_notify_filter(task, filter, callback)
+                .expect("could not wake task");
+
+            if !res.has_tasks_remaining() {
+                // If there are no more waiters we unregister the task.
+                s.unregister_pseudo_task(task)
+                    .expect("could not unregister rwlock task")
+            }
+        });
+    }
+
+    #[inline]
+    fn use_fair_unlock(&self) -> bool {
+        use rand::Rng;
+
+        let now = Instant::now();
+        if now > self.fair_timeout.get() {
+            let rng = self.rng.get();
+
+            // Time between 0 and 1ms.
+            // SAFETY: Is only used while the scheduler is locked.
+            let nanos = unsafe { (*rng).gen_range(0..1_000_000) };
+            self.fair_timeout.set(now + Duration::new(0, nanos));
+
+            true
+        } else {
+            false
+        }
+    }
+}
+
+unsafe impl Send for RawRwLock {}
+unsafe impl Sync for RawRwLock {}

--- a/interfaces/fimo_tasks_int/src/sync/rwlock.rs
+++ b/interfaces/fimo_tasks_int/src/sync/rwlock.rs
@@ -598,9 +598,7 @@ impl RawRwLock {
             let mut callback = MaybeUninit::new(callback);
             let callback = FfiFn::new_value(&mut callback);
 
-            let res = s
-                .pseudo_notify_one(queue, callback)
-                .expect("could not wake task");
+            let res = s.notify_one(queue, callback).expect("could not wake task");
 
             if !res.has_tasks_remaining() {
                 // If there are no more waiters we unregister the task.
@@ -707,7 +705,7 @@ impl RawRwLock {
                             .expect("can not create rwlock task");
 
                         // Try to wait on the task.
-                        match s.pseudo_wait_task_on(curr, task, Some(&mut data), token) {
+                        match s.wait_task_on(curr, task, Some(&mut data), token) {
                             Ok(_) => (),
                             Err(_) => {
                                 // If we could not wait we must check whether the rwlock has other
@@ -795,8 +793,7 @@ impl RawRwLock {
                         .expect("could not fetch rwlock queue task");
 
                     // Try to wait on the task.
-                    match s.pseudo_wait_task_on(curr, queue, Some(&mut data), Self::TOKEN_EXCLUSIVE)
-                    {
+                    match s.wait_task_on(curr, queue, Some(&mut data), Self::TOKEN_EXCLUSIVE) {
                         Ok(_) => (),
                         Err(_) => {
                             // If we could not wait we must check whether the queue has other
@@ -882,7 +879,7 @@ impl RawRwLock {
             let callback = FfiFn::new_value(&mut callback);
 
             let res = s
-                .pseudo_notify_filter(task, filter, callback)
+                .notify_filter(task, filter, callback)
                 .expect("could not wake task");
 
             if !res.has_tasks_remaining() {

--- a/interfaces/fimo_tasks_int/src/sync/spin_wait.rs
+++ b/interfaces/fimo_tasks_int/src/sync/spin_wait.rs
@@ -1,0 +1,60 @@
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+const SLEEP_THRESHOLD: usize = 10;
+const YIELD_THRESHOLDS: usize = 3;
+
+/// A counter used to perform exponential backoff in spin loops.
+#[derive(Debug, Default)]
+pub struct SpinWait {
+    count: usize,
+}
+
+impl SpinWait {
+    /// Creates a new `SpinWait`.
+    #[inline]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Resets a `SpinWait` to its initial state.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.count = 0;
+    }
+
+    /// Spins until the sleep threshold has been reached.
+    ///
+    /// This function returns whether the sleep threshold has been reached, at
+    /// which point further spinning has diminishing returns and the thread
+    /// should be parked instead.
+    ///
+    /// The spin strategy will initially use a CPU-bound loop but will fall back
+    /// to yielding the CPU to the runtime after a few iterations.
+    #[inline]
+    pub fn spin(&mut self, r#yield: impl FnOnce()) -> bool {
+        if self.count >= SLEEP_THRESHOLD {
+            return false;
+        }
+
+        self.count += 1;
+        if self.count <= YIELD_THRESHOLDS {
+            Self::spin_loop(1 << self.count);
+        } else {
+            r#yield()
+        }
+
+        true
+    }
+
+    #[inline]
+    fn spin_loop(iterations: usize) {
+        for _ in 0..iterations {
+            std::hint::spin_loop()
+        }
+    }
+}

--- a/modules/fimo_tasks/Cargo.toml
+++ b/modules/fimo_tasks/Cargo.toml
@@ -21,6 +21,7 @@ fimo_tasks_int = { version = "0.1.0", path = "../../interfaces/fimo_tasks_int" }
 fimo_core_int = { version = "0.1.0", path = "../../interfaces/fimo_core_int", optional = true }
 
 [dev-dependencies]
+rand = "0.8.5"
 pretty_env_logger = "0.4.0"
 module_loading = { path = "../../test_utilities/module_loading" }
 

--- a/modules/fimo_tasks/src/lib.rs
+++ b/modules/fimo_tasks/src/lib.rs
@@ -6,6 +6,7 @@
     missing_debug_implementations,
     rustdoc::broken_intra_doc_links
 )]
+#![feature(strict_provenance)]
 #![feature(thread_local)]
 #![feature(c_unwind)]
 

--- a/modules/fimo_tasks/src/lib.rs
+++ b/modules/fimo_tasks/src/lib.rs
@@ -1,5 +1,5 @@
 //! Implementation of the `fimo-tasks` interface.
-#![feature(c_unwind)]
+#![forbid(clippy::undocumented_unsafe_blocks)]
 #![warn(
     missing_docs,
     rust_2018_idioms,
@@ -7,12 +7,11 @@
     rustdoc::broken_intra_doc_links
 )]
 #![feature(thread_local)]
+#![feature(c_unwind)]
 
 mod runtime;
 mod scheduler;
 mod spin_wait;
-mod stack_allocator;
-mod task_manager;
 mod worker_pool;
 
 #[cfg(feature = "module")]

--- a/modules/fimo_tasks/src/runtime.rs
+++ b/modules/fimo_tasks/src/runtime.rs
@@ -308,8 +308,8 @@ impl IRuntime for Runtime {
                 if let Some(mut scheduler) = self.scheduler.try_lock() {
                     let s = fimo_ffi::ptr::coerce_obj_mut(&mut *scheduler);
 
-                    // SAFETY: We have already checked that the worker exists.
                     let current =
+                        // SAFETY: We have already checked that the worker exists.
                         unsafe { WORKER.get().unwrap_unchecked().current_task().unwrap() };
 
                     // call the function, then schedule the remaining tasks.

--- a/modules/fimo_tasks/src/scheduler.rs
+++ b/modules/fimo_tasks/src/scheduler.rs
@@ -1,5 +1,3 @@
-use crate::stack_allocator::StackAllocator;
-use crate::task_manager::{AssertValidTask, Msg, MsgData, TaskManager};
 use crate::worker_pool::WorkerPool;
 use crate::Runtime;
 use context::Context;
@@ -16,6 +14,12 @@ use std::mem::ManuallyDrop;
 use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Weak;
 use std::time::SystemTime;
+
+pub(crate) mod stack_allocator;
+pub(crate) mod task_manager;
+
+use stack_allocator::StackAllocator;
+use task_manager::{AssertValidTask, Msg, MsgData, TaskManager};
 
 /// Task scheduler.
 #[derive(ObjectId)]
@@ -57,7 +61,11 @@ impl TaskScheduler {
             task_manager: ManuallyDrop::new(TaskManager::new(msg_receiver)),
         };
 
-        // register the scheduler task.
+        // SAFETY: Checking of the conditions
+        // 1. Task is valid as it was just created.
+        // 2. Task is yet unregistered.
+        // 3. The task is stored on the heap and won't therefore be moved.
+        // 4. The task lives as long as the scheduler.
         unsafe { this.register_task(&scheduler_task, &[])? };
 
         Ok(this)
@@ -84,48 +92,13 @@ impl TaskScheduler {
         self.task_manager.find_task(handle)
     }
 
-    /// Registers a task with the runtime for execution.
+    /// Blocks a task until the scheduler has been unlocked.
     ///
     /// # Safety
     ///
-    /// The pointed to value must be kept alive until the runtime releases it.
+    /// The task must be registered with our runtime.
     #[inline]
-    pub unsafe fn register_task(
-        &mut self,
-        task: &DynObj<dyn IRawTask + '_>,
-        deps: &[TaskHandle],
-    ) -> Result<(), Error> {
-        self.task_manager.register_task(task, deps)
-    }
-
-    /// Unregisters a task from the task runtime.
-    pub fn unregister_task(&mut self, task: &DynObj<dyn IRawTask + '_>) -> Result<(), Error> {
-        // we assert that we own the task.
-        let task = unsafe { AssertValidTask::from_raw(task) };
-        self.task_manager.unregister_task(task)
-    }
-
-    /// Registers a block for a task until the dependency completes.
-    ///
-    /// A task may not wait on itself.
-    ///
-    /// # Note
-    ///
-    /// Does not guarantee that the task will wait immediately if it is already scheduled.
-    #[inline]
-    pub fn wait_task_on(
-        &mut self,
-        task: &DynObj<dyn IRawTask + '_>,
-        wait_on: &DynObj<dyn IRawTask + '_>,
-    ) -> Result<(), Error> {
-        // we assert that we own both tasks.
-        let task = unsafe { AssertValidTask::from_raw(task) };
-        let wait_on = unsafe { AssertValidTask::from_raw(wait_on) };
-        self.task_manager.wait_task_on(task, wait_on)
-    }
-
-    #[inline]
-    pub(crate) fn wait_on_scheduler(
+    pub(crate) unsafe fn wait_on_scheduler(
         &mut self,
         task: &DynObj<dyn IRawTask + '_>,
     ) -> Result<(), Error> {
@@ -134,64 +107,31 @@ impl TaskScheduler {
     }
 
     #[inline]
-    pub(crate) fn notify_one_scheduler_waiter(&mut self) -> Result<(), Error> {
+    pub(crate) fn notify_scheduler_unlocked(&mut self) -> Result<(), Error> {
+        // SAFETY: There are two parts of the safety that must be checked:
+        // 1. `scheduler_task` is registered (is trivial).
+        // 2. Waking one task does not cause any undesired effects,
+        // like uninitialized memory accesses.
+        //
+        // We can assert that the second point is true, as `scheduler_task` represents
+        // an always blocked task, used to synchronize the access to the scheduler.
+        // In other words, an equivalent of a mutex. Being woken up by that mutex
+        // does not equal acquiring the lock, but is rather a hint to retry locking it.
+        // Under these semantics, the mutex is only a performance improvement over
+        // calling an equivalent `try_lock` in a loop and has therefore no side effects.
         let scheduler_task = self.scheduler_task.clone();
         unsafe { self.notify_one(&scheduler_task)? };
         Ok(())
     }
 
-    /// Wakes up one task.
-    ///
-    /// Wakes up the task with the highest priority, that is waiting on provided task to finish.
-    /// Returns the number of remaining waiters, if the operation was successful and `Ok(None)`
-    /// if there were no waiters.
-    ///
-    /// # Safety
-    ///
-    /// A waiting task may require that the task fully finishes before
-    /// resuming execution. This function is mainly intended to be
-    /// used for the implementation of condition variables.
-    #[inline]
-    pub unsafe fn notify_one(
-        &mut self,
-        task: &DynObj<dyn IRawTask + '_>,
-    ) -> Result<Option<usize>, Error> {
-        // we assert that we own the task.
-        let task = AssertValidTask::from_raw(task);
-        self.task_manager.notify_one(task)
-    }
-
-    /// Wakes up all tasks.
-    ///
-    /// Wakes up all waiting tasks. Returns the number of tasks that were woken up.
-    ///
-    /// # Safety
-    ///
-    /// A waiting task may require that the task fully finishes before
-    /// resuming execution. This function is mainly intended to be
-    /// used for the implementation of condition variables.
-    #[inline]
-    pub unsafe fn notify_all(&mut self, task: &DynObj<dyn IRawTask + '_>) -> Result<usize, Error> {
-        // we assert that we own the task.
-        let task = AssertValidTask::from_raw(task);
-        self.task_manager.notify_all(task)
-    }
-
-    /// Unblocks a blocked task.
-    #[inline]
-    pub fn unblock_task(&mut self, task: &DynObj<dyn IRawTask + '_>) -> Result<(), Error> {
-        // we assert that we own the task.
-        let task = unsafe { AssertValidTask::from_raw(task) };
-        self.task_manager.unblock_task(task)
-    }
-
+    // Handles the case that a task has finished it's execution.
     fn process_finished(&mut self, task: AssertValidTask) {
         let context = task.context().borrow();
 
         trace!("Cleaning up task {}", context.handle());
         debug!("Task run status: {:?}", context.run_status());
         debug!("Task schedule status: {:?}", context.schedule_status());
-        debug!("Task data: {:?}", unsafe { context.scheduler_data() });
+        debug!("Task data: {:?}", context.scheduler_data());
 
         // task should not be running or have any dependencies at this point
         debug_assert_eq!(context.run_status(), TaskRunStatus::Idle);
@@ -199,31 +139,54 @@ impl TaskScheduler {
             context.schedule_status(),
             TaskScheduleStatus::Aborted | TaskScheduleStatus::Finished
         ));
-        debug_assert!(unsafe { context.scheduler_data().dependencies.is_empty() });
+        debug_assert!(context
+            .scheduler_data()
+            .private_data()
+            .dependencies
+            .is_empty());
 
         trace!("Notify waiters of {}", context.handle());
+
+        // `notify_all` requires the context.
         drop(context);
+
+        // SAFETY: The task has been completed, therefore notifying the waiters
+        // of the task is a safe (and required) operation.
         unsafe {
             self.task_manager
                 .notify_all(task.clone())
                 .expect("Invalid task")
         };
-        let mut context = task.context().borrow_mut();
 
-        trace!("Free task slot of {}", context.handle());
-        if let Some(slot) = unsafe { context.scheduler_data_mut().slot.take() } {
-            if let Err(e) = self.stacks.deallocate(slot) {
-                error!("Could not free task slot, error: {}", e)
+        let mut context = task.context().borrow_mut();
+        let data = context.scheduler_data();
+
+        // If the task panicked, we need to retrieve the panic data from the
+        // shared context and place it in the public context.
+        let panic = {
+            let mut shared = data.shared_data_mut();
+            let mut private = data.private_data_mut();
+
+            trace!("Free task slot of {}", context.handle());
+            if let Some(slot) = private.slot.take() {
+                if let Err(e) = self.stacks.deallocate(slot) {
+                    error!("Could not free task slot, error: {}", e)
+                }
             }
+
+            shared.take_panic()
+        };
+
+        if let Some(panic) = panic {
+            context.set_panic(Some(panic));
+            debug_assert!(context.is_panicking());
         }
 
         trace!("Internal task cleanup");
         context.cleanup();
 
         trace!("Marking task {} as completed", context.handle());
-        unsafe {
-            context.set_run_status(TaskRunStatus::Completed);
-        }
+        context.set_run_status(TaskRunStatus::Completed);
     }
 
     fn process_msg(&mut self) -> bool {
@@ -234,8 +197,8 @@ impl TaskScheduler {
 
         trace!("Processing {} scheduler messages", msgs.len());
         for Msg { task, data } in msgs {
-            let mut context = task.context().borrow_mut();
-            let scheduler_data = unsafe { context.scheduler_data() };
+            let context = task.context().borrow();
+            let scheduler_data = context.scheduler_data();
 
             trace!(
                 "Message for task-id {}, name: {:?}",
@@ -257,17 +220,15 @@ impl TaskScheduler {
             debug_assert_eq!(run_status, TaskRunStatus::Idle);
             debug_assert_eq!(schedule_status, TaskScheduleStatus::Processing);
 
-            // set the processing flag.
-            let scheduler_data = unsafe { context.scheduler_data_mut() };
-            scheduler_data.processing = true;
-            let scheduler_data = unsafe { context.scheduler_data() };
-
             // clear and fetch the status change request and apply it.
-            let request = context.clear_request();
+            // SAFETY: We are the scheduler and are therefore allowed to clear the requests
+            // and apply them.
+            let mut private = scheduler_data.private_data_mut();
             unsafe {
+                let request = context.clear_request();
                 match request {
                     StatusRequest::None => {
-                        if scheduler_data.dependencies.is_empty() {
+                        if private.dependencies.is_empty() {
                             context.set_schedule_status(TaskScheduleStatus::Runnable)
                         } else {
                             context.set_schedule_status(TaskScheduleStatus::Waiting)
@@ -283,26 +244,44 @@ impl TaskScheduler {
             }
 
             // finally process the message
+            // SAFETY: We are toggling and untoggling the flag according to the documentation.
+            unsafe { private.toggle_processing(true) };
+
             trace!("Processing {} message", data.msg_type());
+
+            // The callback may require the context.
+            drop(private);
             drop(context);
+
             match data {
                 MsgData::Yield { f } => {
                     let scheduler = fimo_ffi::ptr::coerce_obj_mut(self);
+
+                    // SAFETY: The api ensures that the task remains blocked until
+                    // the message is processed. We know that the callback was valid
+                    // at the time the task yielded its execution, therefore it must
+                    // have remained valid and we can invoke it.
                     unsafe { f.assume_valid()(scheduler, task.as_raw()) }
                 }
                 MsgData::Completed { aborted } => {
                     let context = task.context().borrow();
-                    if aborted {
-                        trace!("Marking task {} as aborted", context.handle());
-                        unsafe { context.set_schedule_status(TaskScheduleStatus::Aborted) }
-                    } else {
-                        trace!("Marking task {} as finished", context.handle());
-                        unsafe { context.set_schedule_status(TaskScheduleStatus::Finished) }
+
+                    // SAFETY: As the implementation of the scheduler we ensure that
+                    // the operation is well behaved, as no one else is allowed to
+                    // modify the status.
+                    unsafe {
+                        if aborted {
+                            trace!("Marking task {} as aborted", context.handle());
+                            context.set_schedule_status(TaskScheduleStatus::Aborted)
+                        } else {
+                            trace!("Marking task {} as finished", context.handle());
+                            context.set_schedule_status(TaskScheduleStatus::Finished)
+                        }
                     }
                 }
             }
-            let mut context = task.context().borrow_mut();
-            let scheduler_data = unsafe { context.scheduler_data() };
+            let context = task.context().borrow();
+            let scheduler_data = context.scheduler_data();
 
             // the status may have changed.
             trace!("Task {} processed", context.handle());
@@ -310,16 +289,19 @@ impl TaskScheduler {
             debug!("Task schedule status: {:?}", context.schedule_status());
             debug!("Task data: {:?}", scheduler_data);
 
-            // remove the processing flag.
-            let scheduler_data = unsafe { context.scheduler_data_mut() };
-            scheduler_data.processing = false;
+            let mut private = scheduler_data.private_data_mut();
 
-            // the status must be queried again.
+            // SAFETY: See above.
+            // Remove the processing flag.
+            unsafe { private.toggle_processing(false) };
+
+            // The status must be queried again.
             match context.schedule_status() {
                 TaskScheduleStatus::Runnable => {
                     trace!("Inserting task {} into processing queue", context.handle());
+                    drop(private);
                     drop(context);
-                    unsafe { self.task_manager.enqueue(task) };
+                    self.task_manager.enqueue(task);
                 }
                 TaskScheduleStatus::Scheduled | TaskScheduleStatus::Processing => {
                     error!("Invalid schedule status for task {}", context.handle());
@@ -331,6 +313,7 @@ impl TaskScheduler {
                 }
                 TaskScheduleStatus::Aborted | TaskScheduleStatus::Finished => {
                     trace!("Task finished cleaning up");
+                    drop(private);
                     drop(context);
                     self.process_finished(task);
                 }
@@ -347,8 +330,16 @@ impl TaskScheduler {
         stale
     }
 
+    /// Shuts down the worker pool by dropping it.
+    ///
+    /// After being called it is impossible for it to be restarted.
+    ///
+    /// # Note
+    ///
+    /// Calling this method practically make the entire runtime unusable.
     #[inline]
     pub(crate) fn shutdown_worker_pool(&mut self) {
+        // SAFETY: The contract of this method allows this.
         unsafe { ManuallyDrop::drop(&mut self.worker_pool) };
     }
 
@@ -356,25 +347,25 @@ impl TaskScheduler {
         trace!("Running scheduler");
         let no_msgs = self.process_msg();
 
-        let time = SystemTime::now();
-        let queue = self.task_manager.clear_queue();
+        // SAFETY: We are currently scheduling.
+        let queue = unsafe { self.task_manager.clear_queue() };
+
         trace!("Scheduling {} tasks", queue.len());
 
         let mut stale = no_msgs;
+        let time = SystemTime::now();
         let mut min_time = None;
         for Reverse(task) in queue.into_sorted_vec() {
-            let mut context = task.context().borrow_mut();
+            let context = task.context().borrow();
+            let scheduler_data = context.scheduler_data();
 
-            let handle = context.handle();
-            let empty_task = context.is_empty_task();
             let run_status = context.run_status();
             let resume_time = context.resume_time();
             let schedule_status = context.schedule_status();
-            let scheduler_data = unsafe { context.scheduler_data_mut() };
 
             trace!(
                 "Scheduling task {}, name {:?}",
-                handle,
+                context.handle(),
                 task.resolved_name()
             );
             debug!("Task run status: {:?}", run_status);
@@ -382,12 +373,18 @@ impl TaskScheduler {
             debug!("Task data: {:?}", scheduler_data);
             debug_assert_eq!(run_status, TaskRunStatus::Idle);
 
+            let mut private = scheduler_data.private_data_mut();
+            let mut shared = scheduler_data.shared_data_mut();
+
             // The `wait_task_on` method can change the status of a runnable
             // task from `Runnable` to `Waiting` even when it is already enqueued.
-            // If that is the case we must remove the task from the queue.
+            // If that is the case we must remove the task from the queue and
+            // mark it as not in the queue.
             if schedule_status != TaskScheduleStatus::Runnable {
-                info!("Task {} not runnable, skipping", handle);
-                drop(context);
+                info!("Task {} not runnable, skipping", context.handle());
+
+                // SAFETY: The task was removed from the queue.
+                unsafe { private.assert_not_in_queue() };
                 continue;
             }
 
@@ -397,13 +394,15 @@ impl TaskScheduler {
                     "Task resume time {:?} not reached, time {:?}, skipping.",
                     resume_time, time
                 );
+                drop(private);
+                drop(shared);
                 drop(context);
 
                 min_time = Some(min_time.map_or(resume_time, |t| std::cmp::min(t, resume_time)));
 
                 // SAFETY: The task only appeared once in the queue before it was cleared
                 // so moving it to the new queue won't cause any duplicates.
-                unsafe { self.task_manager.enqueue(task) };
+                unsafe { self.task_manager.enqueue_unchecked(task) };
                 continue;
             }
 
@@ -411,14 +410,24 @@ impl TaskScheduler {
             stale = false;
 
             // allocate stack
-            if scheduler_data.context.is_none() && !empty_task {
+            if shared.is_empty_context() && !context.is_empty_task() {
                 // try to allocate the task or reinsert.
                 let (slot, stack) = match self.stacks.allocate() {
                     Ok(r) => r,
                     Err(_) => {
-                        error!("Unable to schedule task {}, retrying later", handle);
+                        error!(
+                            "Unable to schedule task {}, retrying later",
+                            context.handle()
+                        );
+
+                        // make the borrow checker happy.
+                        drop(private);
+                        drop(shared);
                         drop(context);
-                        unsafe { self.task_manager.enqueue(task) };
+
+                        // SAFETY: The task was contained only once in the queue and
+                        // therefore will continue to be as such.
+                        unsafe { self.task_manager.enqueue_unchecked(task) };
 
                         if min_time.is_none() {
                             min_time = Some(time)
@@ -428,19 +437,26 @@ impl TaskScheduler {
                     }
                 };
 
+                // SAFETY: We know that the stack will outlive the context, because the context
+                // lives until the completion of the task and only then will the stack be deallocated.
                 unsafe {
                     let context = Context::new(&stack, crate::worker_pool::task_main);
-                    scheduler_data.slot = Some(slot);
-                    scheduler_data.context = Some(context);
+                    private.slot = Some(slot);
+                    shared.set_context(context);
                 }
             }
 
             // schedule task on worker
+            // SAFETY: The task was removed from the queue.
+            unsafe { private.assert_not_in_queue() };
+            unsafe { context.set_schedule_status(TaskScheduleStatus::Scheduled) };
+            drop(private);
+            drop(shared);
             drop(context);
-            self.worker_pool.schedule_task(task);
+            self.worker_pool.assign_task_to_worker(task);
         }
 
-        self.notify_one_scheduler_waiter()
+        self.notify_scheduler_unlocked()
             .expect("can not notify tasks waiting on the scheduler");
 
         (stale, min_time)
@@ -461,6 +477,7 @@ impl Drop for TaskScheduler {
     fn drop(&mut self) {
         info!("Shutting down task scheduler");
 
+        // SAFETY: We are dropping the scheduler so further drops are safe.
         unsafe {
             // the worker pool is already shut down at this point, so
             // drop the task and the stacks with the allocated memory.
@@ -490,36 +507,50 @@ impl IScheduler for TaskScheduler {
         task: &DynObj<dyn IRawTask + '_>,
         wait_on: &[TaskHandle],
     ) -> fimo_module::Result<()> {
-        self.register_task(task, wait_on)
+        self.task_manager.register_task(task, wait_on)
     }
 
-    fn unregister_task(&mut self, task: &DynObj<dyn IRawTask + '_>) -> fimo_module::Result<()> {
-        self.unregister_task(task)
+    unsafe fn unregister_task(
+        &mut self,
+        task: &DynObj<dyn IRawTask + '_>,
+    ) -> fimo_module::Result<()> {
+        // SAFETY: We assume that the task is registered with our runtime.
+        let task = AssertValidTask::from_raw(task);
+        self.task_manager.unregister_task(task)
     }
 
-    fn wait_task_on(
+    unsafe fn wait_task_on(
         &mut self,
         task: &DynObj<dyn IRawTask + '_>,
         on: &DynObj<dyn IRawTask + '_>,
     ) -> fimo_module::Result<()> {
-        self.wait_task_on(task, on)
+        // SAFETY: We assume that the tasks are both registered with our runtime.
+        let task = AssertValidTask::from_raw(task);
+        let on = AssertValidTask::from_raw(on);
+        self.task_manager.wait_task_on(task, on)
     }
 
     unsafe fn notify_one(
         &mut self,
         task: &DynObj<dyn IRawTask + '_>,
     ) -> fimo_module::Result<Option<usize>> {
-        self.notify_one(task)
+        // SAFETY: We assume that the task is registered with our runtime.
+        let task = AssertValidTask::from_raw(task);
+        self.task_manager.notify_one(task)
     }
 
     unsafe fn notify_all(
         &mut self,
         task: &DynObj<dyn IRawTask + '_>,
     ) -> fimo_module::Result<usize> {
-        self.notify_all(task)
+        // SAFETY: We assume that the task is registered with our runtime.
+        let task = AssertValidTask::from_raw(task);
+        self.task_manager.notify_all(task)
     }
 
-    fn unblock_task(&mut self, task: &DynObj<dyn IRawTask + '_>) -> fimo_module::Result<()> {
-        self.unblock_task(task)
+    unsafe fn unblock_task(&mut self, task: &DynObj<dyn IRawTask + '_>) -> fimo_module::Result<()> {
+        // SAFETY: We assume that the task is registered with our runtime.
+        let task = AssertValidTask::from_raw(task);
+        self.task_manager.unblock_task(task)
     }
 }

--- a/modules/fimo_tasks/src/scheduler.rs
+++ b/modules/fimo_tasks/src/scheduler.rs
@@ -574,4 +574,49 @@ impl IScheduler for TaskScheduler {
         let task = AssertValidTask::from_raw(task);
         self.task_manager.unblock_task(task)
     }
+
+    unsafe fn pseudo_num_waiting_tasks(&self, task: fimo_tasks_int::raw::PseudoTask) -> usize {
+        self.task_manager.pseudo_num_waiting_tasks(task)
+    }
+
+    unsafe fn register_or_fetch_pseudo_task(
+        &mut self,
+        addr: *const (),
+    ) -> fimo_module::Result<fimo_tasks_int::raw::PseudoTask> {
+        self.task_manager.register_or_fetch_pseudo_task(addr)
+    }
+
+    unsafe fn unregister_pseudo_task(
+        &mut self,
+        task: fimo_tasks_int::raw::PseudoTask,
+    ) -> fimo_module::Result<()> {
+        self.task_manager.unregister_pseudo_task(task)
+    }
+
+    unsafe fn pseudo_wait_task_on(
+        &mut self,
+        task: &DynObj<dyn IRawTask + '_>,
+        on: fimo_tasks_int::raw::PseudoTask,
+        data_addr: Option<&mut MaybeUninit<WakeupData>>,
+    ) -> fimo_module::Result<()> {
+        // SAFETY: We assume that the task is registered with our runtime.
+        let task = AssertValidTask::from_raw(task);
+        self.task_manager.pseudo_wait_task_on(task, on, data_addr)
+    }
+
+    unsafe fn pseudo_notify_one(
+        &mut self,
+        task: fimo_tasks_int::raw::PseudoTask,
+        data: WakeupData,
+    ) -> fimo_module::Result<Option<usize>> {
+        self.task_manager.pseudo_notify_one(task, data)
+    }
+
+    unsafe fn pseudo_notify_all(
+        &mut self,
+        task: fimo_tasks_int::raw::PseudoTask,
+        data: WakeupData,
+    ) -> fimo_module::Result<usize> {
+        self.task_manager.pseudo_notify_all(task, data)
+    }
 }

--- a/modules/fimo_tasks/src/scheduler.rs
+++ b/modules/fimo_tasks/src/scheduler.rs
@@ -623,4 +623,14 @@ impl IScheduler for TaskScheduler {
     ) -> fimo_module::Result<usize> {
         self.task_manager.pseudo_notify_all(task, data)
     }
+
+    unsafe fn pseudo_notify_filter(
+        &mut self,
+        task: fimo_tasks_int::raw::PseudoTask,
+        filter: FfiFn<'_, dyn FnMut(WaitToken) -> fimo_tasks_int::runtime::NotifyFilterOp + '_, u8>,
+        data_callback: FfiFn<'_, dyn FnOnce(NotifyResult) -> WakeupToken + '_, u8>,
+    ) -> fimo_module::Result<NotifyResult> {
+        self.task_manager
+            .pseudo_notify_filter(task, filter, data_callback)
+    }
 }

--- a/modules/fimo_tasks/src/scheduler/stack_allocator.rs
+++ b/modules/fimo_tasks/src/scheduler/stack_allocator.rs
@@ -70,6 +70,12 @@ impl StackAllocator {
         })
     }
 
+    /// Allocates a new stack.
+    ///
+    /// The return type is comprised of a [`TaskSlot`] (handle/id of the allocation)
+    /// and a [`Stack`] (span of the allocated memory region).
+    ///
+    /// The allocated stack can be deallocated with [`deallocate`](#method.deallocate).
     pub fn allocate(&mut self) -> Result<(TaskSlot, Stack), Error> {
         trace!("Allocating a new stack and slot");
 
@@ -112,7 +118,7 @@ impl StackAllocator {
         let stack = stack.as_ref().expect("Shouldn't happen");
         let (top, bottom) = (stack.0.top(), stack.0.bottom());
 
-        // safety: we know that the addresses are valid, because they
+        // SAFETY: we know that the addresses are valid, because they
         // originate from an allocated stack, that won't be deallocated
         // until we free the slot.
         let stack = unsafe { Stack::new(top, bottom) };
@@ -121,6 +127,10 @@ impl StackAllocator {
         Ok((slot, stack))
     }
 
+    /// Deallocates an allocated stack.
+    ///
+    /// Logically deallocates a stack but may keep its memory allocated to
+    /// be reused by a following allocation.
     pub fn deallocate(&mut self, slot: TaskSlot) -> Result<(), Error> {
         trace!("Deallocating task slot {:?}", slot);
 

--- a/modules/fimo_tasks/src/scheduler/task_manager.rs
+++ b/modules/fimo_tasks/src/scheduler/task_manager.rs
@@ -411,6 +411,14 @@ impl TaskManager {
                 context.handle(),
                 wait_on_context.handle()
             );
+
+            // The caller relies on the fact, that the data is initialized once the task
+            // has been woken up. Normally that would be implemented in the wake routine,
+            // but as we are skipping the wait entirely it is now our responsibility.
+            if let Some(data_addr) = data_addr {
+                data_addr.write(WakeupData::None);
+            }
+
             return Ok(());
         }
 

--- a/modules/fimo_tasks/src/worker_pool.rs
+++ b/modules/fimo_tasks/src/worker_pool.rs
@@ -515,7 +515,7 @@ pub(crate) extern "C" fn worker_main(thread_context: Transfer) -> ! {
             // read msg data.
             // SAFETY: `yield_to_worker` writes the pointer of the message
             // in the `Transfer` and ensures that it won't drop it.
-            unsafe { (tr.data as *const MsgData<'_>).read() }
+            unsafe { std::ptr::from_exposed_addr::<MsgData<'_>>(tr.data).read() }
         } else {
             // remove task
             worker.current_task.set(None);
@@ -577,7 +577,7 @@ pub(crate) unsafe fn yield_to_worker(msg_data: MsgData<'_>) {
         // pass the pointer to the data back to the worker function.
         // the worker will read the data, so we must make sure that it won't be dropped by us.
         let msg_data = MaybeUninit::new(msg_data);
-        worker_context.resume(msg_data.as_ptr() as usize)
+        worker_context.resume(msg_data.as_ptr().expose_addr())
     };
 
     // at this point we may be on a different thread than we started

--- a/modules/fimo_tasks/tests/runtime.rs
+++ b/modules/fimo_tasks/tests/runtime.rs
@@ -1,15 +1,19 @@
+use fimo_ffi::cell::AtomicRefCell;
 use fimo_ffi::DynObj;
 use fimo_module::Error;
 use fimo_tasks::Builder;
+use fimo_tasks_int::raw::{IRawTask, ISchedulerContext, TaskScheduleStatus};
 use fimo_tasks_int::runtime::{
-    get_runtime, init_runtime, is_worker, IRuntime, IRuntimeExt, IScheduler,
+    current_runtime, get_runtime, init_runtime, is_worker, IRuntime, IRuntimeExt, IScheduler,
+    WaitStatus,
 };
 use fimo_tasks_int::task::ParallelBuilder;
 use std::sync::Once;
+use std::time::{Duration, SystemTime};
 
 static INIT: Once = Once::new();
 
-fn new_runtime(f: impl FnOnce(&DynObj<dyn IRuntime>) -> Result<(), Error>) -> Result<(), Error> {
+fn new_runtime<R>(f: impl FnOnce(&DynObj<dyn IRuntime>) -> Result<R, Error>) -> Result<R, Error> {
     INIT.call_once(pretty_env_logger::init);
 
     let runtime = Builder::new().build()?;
@@ -17,7 +21,9 @@ fn new_runtime(f: impl FnOnce(&DynObj<dyn IRuntime>) -> Result<(), Error>) -> Re
     f(runtime)
 }
 
-pub fn enter_and_init_runtime(f: impl FnOnce() -> Result<(), Error> + Send) -> Result<(), Error> {
+pub fn enter_and_init_runtime<R: Send>(
+    f: impl FnOnce() -> Result<R, Error> + Send,
+) -> Result<R, Error> {
     new_runtime(move |runtime| {
         assert!(!is_worker());
         assert!(runtime.worker_id().is_none());
@@ -35,6 +41,22 @@ pub fn enter_and_init_runtime(f: impl FnOnce() -> Result<(), Error> + Send) -> R
 
         res
     })
+}
+
+#[test]
+fn eq() {
+    let res = enter_and_init_runtime(|| Ok(5));
+    assert_eq!(res.unwrap(), 5)
+}
+
+#[test]
+#[should_panic]
+fn error() {
+    #[allow(unreachable_code)]
+    let _ = enter_and_init_runtime(|| {
+        panic!("Hey");
+        Ok(())
+    });
 }
 
 #[test]
@@ -102,6 +124,188 @@ fn block_on_multiple_unique() -> Result<(), Error> {
             .unwrap();
 
         assert!(r.enter_scheduler(|s, _| s.worker_ids().iter().all(|id| ids.contains(id))));
+        Ok(())
+    })
+}
+
+#[test]
+fn block_on() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let r = unsafe { get_runtime() };
+
+        let n = AtomicRefCell::new(0);
+        let t = r.spawn(
+            || {
+                let mut n = n.borrow_mut();
+                *n = 5;
+            },
+            &[],
+        )?;
+
+        r.block_on(
+            || {
+                let mut n = n.borrow_mut();
+                assert_eq!(*n, 5);
+
+                *n = 10;
+            },
+            &[t.handle()],
+        )?;
+
+        let n = n.borrow();
+        assert_eq!(*n, 10);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn spawn() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let n = AtomicRefCell::new(0);
+        let r = unsafe { get_runtime() };
+
+        const NUM_TASKS: usize = 100;
+
+        let mut tasks = vec![r.spawn(|| {}, &[])?];
+        for _ in 0..NUM_TASKS {
+            let handle = tasks.last().unwrap().handle();
+            let t = r.spawn(
+                || {
+                    let mut n = n.borrow_mut();
+                    *n += 1;
+                },
+                &[handle],
+            )?;
+            tasks.push(t);
+        }
+
+        drop(tasks);
+        let n = n.borrow();
+        assert_eq!(*n, NUM_TASKS);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn sleep_for() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let before_sleep = SystemTime::now();
+        let duration = Duration::from_millis(500);
+        let r = unsafe { get_runtime() };
+
+        r.yield_for(duration);
+        let after_sleep = SystemTime::now();
+        let sleep_duration = after_sleep.duration_since(before_sleep).unwrap();
+        assert!(duration <= sleep_duration);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn sleep_until() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let before_sleep = SystemTime::now();
+        let duration = Duration::from_millis(500);
+        let sleep_until = before_sleep + duration;
+        let r = unsafe { get_runtime() };
+
+        r.yield_until(sleep_until);
+        let after_sleep = SystemTime::now();
+        let sleep_duration = after_sleep.duration_since(before_sleep).unwrap();
+        assert!(duration <= sleep_duration);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn block() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let r = current_runtime().unwrap();
+
+        let (sx, rx) = std::sync::mpsc::channel();
+
+        let mut t = r.spawn(
+            || {
+                let r = current_runtime().unwrap();
+                // reimplementation of `block_now` to also send a message.
+                r.yield_and_enter(move |_, curr| {
+                    sx.send(()).expect("unable to send signal");
+                    curr.context().borrow().request_block();
+                })
+            },
+            &[],
+        )?;
+
+        // wait until the task blocks
+        rx.recv().unwrap();
+
+        // synchronize the current task with the scheduler to make shure
+        // that the task has been blocked.
+        r.yield_now();
+
+        let status = t.as_raw().context_atomic().schedule_status();
+        assert_eq!(status, TaskScheduleStatus::Blocked);
+
+        t.unblock()?;
+
+        let res = t.join();
+        assert!(matches!(res, Ok(_)));
+
+        Ok(())
+    })
+}
+
+#[test]
+fn abort() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let r = current_runtime().unwrap();
+
+        let t = r.spawn(
+            || {
+                let r = current_runtime().unwrap();
+                unsafe { r.abort_now() }
+            },
+            &[],
+        )?;
+
+        let res = t.wait();
+        assert_eq!(res, None);
+
+        let status = t.as_raw().context_atomic().schedule_status();
+        assert_eq!(status, TaskScheduleStatus::Aborted);
+
+        let res = t.join();
+        assert!(res.is_err());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn wait() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let r = current_runtime().unwrap();
+
+        let t = r.spawn(|| {}, &[])?;
+        let t_handle = t.handle();
+
+        assert!(matches!(r.wait_on(t_handle), Ok(WaitStatus::Completed)));
+        let status = t.as_raw().context_atomic().schedule_status();
+        assert_eq!(status, TaskScheduleStatus::Finished);
+        let _ = t.join();
+
+        // task already finished.
+        assert!(matches!(r.wait_on(t_handle), Ok(WaitStatus::Skipped)));
+
+        // waiting on itself is simply skipped.
+        let self_handle =
+            r.yield_and_enter(|_, cur| unsafe { cur.context().borrow().handle().assume_init() });
+        assert!(matches!(r.wait_on(self_handle), Ok(WaitStatus::Skipped)));
+
         Ok(())
     })
 }

--- a/modules/fimo_tasks/tests/sync/barrier.rs
+++ b/modules/fimo_tasks/tests/sync/barrier.rs
@@ -1,0 +1,35 @@
+use crate::enter_and_init_runtime;
+use fimo_module::Error;
+use fimo_tasks_int::{sync::Barrier, task::ParallelBuilder};
+use std::sync::Arc;
+
+#[test]
+fn test_barrier() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        const N: usize = 10;
+
+        let barrier = Arc::new(Barrier::new(N));
+        let b = barrier.clone();
+
+        let tasks = ParallelBuilder::new()
+            .num_tasks(Some(N - 1))
+            .spawn(move || b.wait().is_leader(), &[])?;
+
+        // all tasks should be waiting for the barrier.
+        let mut leader_found = barrier.wait().is_leader();
+
+        // one task should be the leader.
+        for task in tasks {
+            if let Some(leader) = task.wait() {
+                if *leader {
+                    assert!(!leader_found);
+                    leader_found = true
+                }
+            }
+        }
+
+        assert!(leader_found);
+
+        Ok(())
+    })
+}

--- a/modules/fimo_tasks/tests/sync/condvar.rs
+++ b/modules/fimo_tasks/tests/sync/condvar.rs
@@ -1,0 +1,256 @@
+use std::sync::Arc;
+
+use fimo_module::Error;
+use fimo_tasks_int::{
+    runtime::{current_runtime, IRuntimeExt},
+    sync::{Condvar, Mutex},
+    task::ParallelBuilder,
+};
+
+use crate::enter_and_init_runtime;
+
+#[test]
+fn smoke() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let c = Condvar::new();
+        c.notify_one();
+        c.notify_all();
+
+        Ok(())
+    })
+}
+
+#[test]
+fn notify_one() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let m = Arc::new(Mutex::new(()));
+        let m2 = m.clone();
+        let c = Arc::new(Condvar::new());
+        let c2 = c.clone();
+
+        let runtime = current_runtime().unwrap();
+        let mut g = m.lock();
+        let _t = runtime.spawn(
+            move || {
+                let _g = m2.lock();
+                c2.notify_one();
+            },
+            &[],
+        );
+        c.wait(&mut g);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn notify_all() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        const N: usize = 10;
+
+        let data = Arc::new((Mutex::new(0), Condvar::new()));
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let _t = {
+            let data = data.clone();
+            let tx = tx.clone();
+            ParallelBuilder::new().num_tasks(Some(N)).spawn(
+                move || {
+                    let &(ref lock, ref cond) = &*data;
+                    let mut cnt = lock.lock();
+                    *cnt += 1;
+                    if *cnt == N {
+                        tx.send(()).unwrap();
+                    }
+                    while *cnt != 0 {
+                        cond.wait(&mut cnt);
+                    }
+                    tx.send(()).unwrap();
+                },
+                &[],
+            )?
+        };
+        drop(tx);
+
+        let &(ref lock, ref cond) = &*data;
+        rx.recv().unwrap();
+        let mut cnt = lock.lock();
+        *cnt = 0;
+        cond.notify_all();
+        drop(cnt);
+
+        for _ in 0..N {
+            rx.recv().unwrap();
+        }
+
+        Ok(())
+    })
+}
+
+#[test]
+fn notify_one_return_true() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let m = Arc::new(Mutex::new(()));
+        let m2 = m.clone();
+        let c = Arc::new(Condvar::new());
+        let c2 = c.clone();
+
+        let mut g = m.lock();
+        let runtime = current_runtime().unwrap();
+        let _t = runtime.spawn(
+            move || {
+                let _g = m2.lock();
+                assert!(c2.notify_one());
+            },
+            &[],
+        );
+        c.wait(&mut g);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn notify_one_return_false() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let m = Arc::new(Mutex::new(()));
+        let c = Arc::new(Condvar::new());
+
+        let runtime = current_runtime().unwrap();
+        let _t = runtime.spawn(
+            move || {
+                let _g = m.lock();
+                assert!(!c.notify_one());
+            },
+            &[],
+        );
+
+        Ok(())
+    })
+}
+
+#[test]
+fn notify_all_return() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        const N: usize = 10;
+
+        let data = Arc::new((Mutex::new(0), Condvar::new()));
+        let (tx, rx) = std::sync::mpsc::channel();
+
+        let t = {
+            let data = data.clone();
+            let tx = tx.clone();
+            ParallelBuilder::new().num_tasks(Some(N)).spawn(
+                move || {
+                    let &(ref lock, ref cond) = &*data;
+                    let mut cnt = lock.lock();
+                    *cnt += 1;
+                    if *cnt == N {
+                        tx.send(()).unwrap();
+                    }
+                    while *cnt != 0 {
+                        cond.wait(&mut cnt);
+                    }
+                    tx.send(()).unwrap();
+                },
+                &[],
+            )?
+        };
+        drop(tx);
+
+        let &(ref lock, ref cond) = &*data;
+        rx.recv().unwrap();
+        let mut cnt = lock.lock();
+        *cnt = 0;
+        assert_eq!(cond.notify_all(), N);
+        drop(cnt);
+
+        for _ in 0..N {
+            rx.recv().unwrap();
+        }
+
+        drop(t);
+
+        assert_eq!(cond.notify_all(), 0);
+
+        Ok(())
+    })
+}
+
+#[test]
+#[should_panic]
+fn two_mutexes() {
+    let _ = enter_and_init_runtime(|| {
+        let m = Arc::new(Mutex::new(()));
+        let m2 = m.clone();
+        let m3 = Arc::new(Mutex::new(()));
+        let c = Arc::new(Condvar::new());
+        let c2 = c.clone();
+
+        // Make sure we don't leave the child thread dangling
+        struct PanicGuard<'a>(&'a Condvar);
+        impl<'a> Drop for PanicGuard<'a> {
+            fn drop(&mut self) {
+                self.0.notify_one();
+            }
+        }
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        let g = m.lock();
+
+        let runtime = current_runtime().unwrap();
+        let _t = runtime.spawn(
+            move || {
+                let mut g = m2.lock();
+                tx.send(()).unwrap();
+                c2.wait(&mut g);
+            },
+            &[],
+        )?;
+
+        drop(g);
+        rx.recv().unwrap();
+        let _g = m.lock();
+        let _guard = PanicGuard(&*c);
+        c.wait(&mut m3.lock());
+
+        Ok(())
+    });
+}
+#[test]
+fn two_mutexes_disjoint() {
+    let _ = enter_and_init_runtime(|| {
+        let m = Arc::new(Mutex::new(()));
+        let m2 = m.clone();
+        let m3 = Arc::new(Mutex::new(()));
+        let m4 = m3.clone();
+        let c = Arc::new(Condvar::new());
+        let c2 = c.clone();
+        let c3 = c.clone();
+
+        let mut g = m.lock();
+        let runtime = current_runtime().unwrap();
+        let _t = runtime.spawn(
+            move || {
+                let _g = m2.lock();
+                c2.notify_one();
+            },
+            &[],
+        )?;
+        c.wait(&mut g);
+        drop(g);
+
+        let mut g = m3.lock();
+        let _t = runtime.spawn(
+            move || {
+                let _g = m4.lock();
+                c3.notify_one();
+            },
+            &[],
+        )?;
+        let _ = c.wait(&mut g);
+        drop(g);
+
+        Ok(())
+    });
+}

--- a/modules/fimo_tasks/tests/sync/mod.rs
+++ b/modules/fimo_tasks/tests/sync/mod.rs
@@ -1,0 +1,1 @@
+mod mutex;

--- a/modules/fimo_tasks/tests/sync/mod.rs
+++ b/modules/fimo_tasks/tests/sync/mod.rs
@@ -1,2 +1,3 @@
+mod barrier;
 mod condvar;
 mod mutex;

--- a/modules/fimo_tasks/tests/sync/mod.rs
+++ b/modules/fimo_tasks/tests/sync/mod.rs
@@ -1,3 +1,4 @@
 mod barrier;
 mod condvar;
 mod mutex;
+mod rwlock;

--- a/modules/fimo_tasks/tests/sync/mod.rs
+++ b/modules/fimo_tasks/tests/sync/mod.rs
@@ -1,1 +1,2 @@
+mod condvar;
 mod mutex;

--- a/modules/fimo_tasks/tests/sync/mutex.rs
+++ b/modules/fimo_tasks/tests/sync/mutex.rs
@@ -45,7 +45,7 @@ fn lock() -> Result<(), Error> {
         let m2 = m.clone();
 
         let tasks = ParallelBuilder::new().num_tasks(Some(NUM_TASKS)).spawn(
-            || {
+            move || {
                 let mut l = m2.lock();
                 *l += 1;
             },

--- a/modules/fimo_tasks/tests/sync/mutex.rs
+++ b/modules/fimo_tasks/tests/sync/mutex.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+
+use fimo_module::Error;
+use fimo_tasks_int::{sync::Mutex, task::ParallelBuilder};
+
+use crate::enter_and_init_runtime;
+
+#[test]
+fn new() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let _m = Mutex::new(());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn inner() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let m = Mutex::new(5);
+        assert_eq!(m.into_inner(), 5);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn get_mut() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let mut m = Mutex::new(5);
+        *m.get_mut() = 10;
+
+        let l = m.lock();
+        assert_eq!(*l, 10);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn lock() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        const NUM_TASKS: usize = 100;
+        let m: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
+        let m2 = m.clone();
+
+        let tasks = ParallelBuilder::new().num_tasks(Some(NUM_TASKS)).spawn(
+            || {
+                let mut l = m2.lock();
+                *l += 1;
+            },
+            &[],
+        )?;
+
+        for t in tasks {
+            let _ = t.join();
+        }
+
+        let l = m.lock();
+        assert_eq!(*l, NUM_TASKS);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn try_lock() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let m = Mutex::new(5);
+        let l = m.try_lock();
+        assert!(matches!(l, Some(_)));
+
+        let l2 = m.try_lock();
+        assert!(matches!(l2, None));
+
+        drop(l);
+        let l = m.try_lock();
+        assert!(matches!(l, Some(_)));
+
+        Ok(())
+    })
+}

--- a/modules/fimo_tasks/tests/sync/rwlock.rs
+++ b/modules/fimo_tasks/tests/sync/rwlock.rs
@@ -1,0 +1,428 @@
+// Copyright 2016 Amanieu d'Antras
+//
+// Licensed under the Apache License, Version 2.0, <LICENSE-APACHE or
+// http://apache.org/licenses/LICENSE-2.0> or the MIT license <LICENSE-MIT or
+// http://opensource.org/licenses/MIT>, at your option. This file may not be
+// copied, modified, or distributed except according to those terms.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    mpsc::channel,
+    Arc,
+};
+
+use fimo_module::Error;
+use fimo_tasks_int::{
+    runtime::{current_runtime, IRuntimeExt},
+    sync::RwLock,
+    task::ParallelBuilder,
+};
+use rand::Rng;
+
+use crate::enter_and_init_runtime;
+
+#[derive(Eq, PartialEq, Debug)]
+struct NonCopy(i32);
+
+#[test]
+fn smoke() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let l = RwLock::new(());
+        drop(l.read());
+        drop(l.write());
+        drop((l.read(), l.read()));
+        drop(l.write());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn frob() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        const N: u32 = 10;
+        const M: u32 = 1000;
+
+        let r = Arc::new(RwLock::new(()));
+        let (tx, rx) = channel::<()>();
+        {
+            let tx = tx.clone();
+            ParallelBuilder::new().num_tasks(Some(N as usize)).spawn(
+                move || {
+                    let mut rng = rand::thread_rng();
+                    for _ in 0..M {
+                        if rng.gen_bool(1.0 / N as f64) {
+                            drop(r.write());
+                        } else {
+                            drop(r.read());
+                        }
+                    }
+                    drop(tx);
+                },
+                &[],
+            )?;
+        }
+        drop(tx);
+        let _ = rx.recv();
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rw_arc_no_poison_wr() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let runtime = current_runtime().unwrap();
+
+        let arc = Arc::new(RwLock::new(1));
+        let arc2 = arc.clone();
+        let _: Result<(), _> = runtime
+            .spawn(
+                move || {
+                    let _lock = arc2.write();
+                    panic!();
+                },
+                &[],
+            )?
+            .join();
+        let lock = arc.read();
+        assert_eq!(*lock, 1);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rw_arc_no_poison_ww() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let runtime = current_runtime().unwrap();
+
+        let arc = Arc::new(RwLock::new(1));
+        let arc2 = arc.clone();
+        let _: Result<(), _> = runtime
+            .spawn(
+                move || {
+                    let _lock = arc2.write();
+                    panic!();
+                },
+                &[],
+            )?
+            .join();
+        let lock = arc.write();
+        assert_eq!(*lock, 1);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rw_arc_no_poison_rr() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let runtime = current_runtime().unwrap();
+
+        let arc = Arc::new(RwLock::new(1));
+        let arc2 = arc.clone();
+        let _: Result<(), _> = runtime
+            .spawn(
+                move || {
+                    let _lock = arc2.read();
+                    panic!();
+                },
+                &[],
+            )?
+            .join();
+        let lock = arc.read();
+        assert_eq!(*lock, 1);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rw_arc_no_poison_rw() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let runtime = current_runtime().unwrap();
+
+        let arc = Arc::new(RwLock::new(1));
+        let arc2 = arc.clone();
+        let _: Result<(), _> = runtime
+            .spawn(
+                move || {
+                    let _lock = arc2.read();
+                    panic!();
+                },
+                &[],
+            )?
+            .join();
+        let lock = arc.write();
+        assert_eq!(*lock, 1);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rw_arc() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let runtime = current_runtime().unwrap();
+
+        let arc = Arc::new(RwLock::new(0));
+        let arc2 = arc.clone();
+        let (tx, rx) = channel();
+
+        runtime.spawn(
+            move || {
+                let runtime = current_runtime().unwrap();
+                let mut lock = arc2.write();
+                for _ in 0..10 {
+                    let tmp = *lock;
+                    *lock = -1;
+                    runtime.yield_now();
+                    *lock = tmp + 1;
+                }
+                tx.send(()).unwrap();
+            },
+            &[],
+        )?;
+
+        let children = {
+            let arc3 = arc.clone();
+            ParallelBuilder::new().num_tasks(Some(5)).spawn(
+                move || {
+                    let lock = arc3.read();
+                    assert!(*lock >= 0);
+                },
+                &[],
+            )?
+        };
+
+        // Wait for children to pass their asserts
+        for r in children {
+            assert!(r.join().is_ok());
+        }
+
+        // Wait for writer to finish
+        rx.recv().unwrap();
+        let lock = arc.read();
+        assert_eq!(*lock, 10);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rw_arc_access_in_unwind() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let runtime = current_runtime().unwrap();
+
+        let arc = Arc::new(RwLock::new(1));
+        let arc2 = arc.clone();
+        let _: Result<(), _> = runtime
+            .spawn(
+                move || {
+                    struct Unwinder {
+                        i: Arc<RwLock<isize>>,
+                    }
+                    impl Drop for Unwinder {
+                        fn drop(&mut self) {
+                            let mut lock = self.i.write();
+                            *lock += 1;
+                        }
+                    }
+                    let _u = Unwinder { i: arc2 };
+                    panic!();
+                },
+                &[],
+            )?
+            .join();
+        let lock = arc.read();
+        assert_eq!(*lock, 2);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rwlock_unsized() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let rw: &RwLock<[i32]> = &RwLock::new([1, 2, 3]) as _;
+        {
+            let b = &mut *rw.write();
+            b[0] = 4;
+            b[2] = 5;
+        }
+        let comp: &[i32] = &[4, 2, 5];
+        assert_eq!(&*rw.read(), comp);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rwlock_try_read() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let lock = RwLock::new(0isize);
+        {
+            let read_guard = lock.read();
+
+            let read_result = lock.try_read();
+            assert!(
+                read_result.is_some(),
+                "try_read should succeed while read_guard is in scope"
+            );
+
+            drop(read_guard);
+        }
+        {
+            let write_guard = lock.write();
+
+            let read_result = lock.try_read();
+            assert!(
+                read_result.is_none(),
+                "try_read should fail while write_guard is in scope"
+            );
+
+            drop(write_guard);
+        }
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rwlock_try_write() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let lock = RwLock::new(0isize);
+        {
+            let read_guard = lock.read();
+
+            let write_result = lock.try_write();
+            assert!(
+                write_result.is_none(),
+                "try_write should fail while read_guard is in scope"
+            );
+            assert!(lock.is_locked());
+            assert!(!lock.is_locked_exclusive());
+
+            drop(read_guard);
+        }
+        {
+            let write_guard = lock.write();
+
+            let write_result = lock.try_write();
+            assert!(
+                write_result.is_none(),
+                "try_write should fail while write_guard is in scope"
+            );
+            assert!(lock.is_locked());
+            assert!(lock.is_locked_exclusive());
+
+            drop(write_guard);
+        }
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_into_inner() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let m = RwLock::new(NonCopy(10));
+        assert_eq!(m.into_inner(), NonCopy(10));
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_into_inner_drop() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        struct Foo(Arc<AtomicUsize>);
+        impl Drop for Foo {
+            fn drop(&mut self) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+        let num_drops = Arc::new(AtomicUsize::new(0));
+        let m = RwLock::new(Foo(num_drops.clone()));
+        assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+        {
+            let _inner = m.into_inner();
+            assert_eq!(num_drops.load(Ordering::SeqCst), 0);
+        }
+        assert_eq!(num_drops.load(Ordering::SeqCst), 1);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_get_mut() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let mut m = RwLock::new(NonCopy(10));
+        *m.get_mut() = NonCopy(20);
+        assert_eq!(m.into_inner(), NonCopy(20));
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rwlockguard_sync() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        fn sync<T: Sync>(_: T) {}
+
+        let rwlock = RwLock::new(());
+        sync(rwlock.read());
+        sync(rwlock.write());
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rwlock_debug() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let x = RwLock::new(vec![0u8, 10]);
+
+        assert_eq!(format!("{:?}", x), "RwLock { data: [0, 10] }");
+        let _lock = x.write();
+        assert_eq!(format!("{:?}", x), "RwLock { data: <locked> }");
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_clone() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let rwlock = RwLock::new(Arc::new(1));
+        let a = rwlock.read();
+        let b = a.clone();
+        assert_eq!(Arc::strong_count(&b), 2);
+
+        Ok(())
+    })
+}
+
+#[test]
+fn test_rw_write_is_locked() -> Result<(), Error> {
+    enter_and_init_runtime(|| {
+        let lock = RwLock::new(0isize);
+        {
+            let _read_guard = lock.read();
+
+            assert!(lock.is_locked());
+            assert!(!lock.is_locked_exclusive());
+        }
+
+        {
+            let _write_guard = lock.write();
+
+            assert!(lock.is_locked());
+            assert!(lock.is_locked_exclusive());
+        }
+
+        Ok(())
+    })
+}

--- a/utilities/fimo_ffi/src/lib.rs
+++ b/utilities/fimo_ffi/src/lib.rs
@@ -12,6 +12,7 @@
 #![feature(try_trait_v2_residual)]
 #![feature(const_slice_ptr_len)]
 #![feature(alloc_layout_extra)]
+#![feature(strict_provenance)]
 #![feature(const_trait_impl)]
 #![feature(must_not_suspend)]
 #![feature(try_reserve_kind)]

--- a/utilities/fimo_ffi/src/obj_arc.rs
+++ b/utilities/fimo_ffi/src/obj_arc.rs
@@ -2265,7 +2265,7 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for RawObjArc<T, A> {
     }
 }
 
-trait DropSpec {
+pub(crate) trait DropSpec {
     fn drop_inner(&mut self);
 }
 

--- a/utilities/fimo_ffi/src/obj_arc.rs
+++ b/utilities/fimo_ffi/src/obj_arc.rs
@@ -2107,7 +2107,7 @@ fn data_offset_align(align: usize) -> isize {
 }
 
 fn is_dangling<T: ?Sized>(ptr: *mut T) -> bool {
-    let address = ptr as *mut () as usize;
+    let address = (ptr as *mut ()).addr();
     address == usize::MAX
 }
 

--- a/utilities/fimo_ffi/src/ptr.rs
+++ b/utilities/fimo_ffi/src/ptr.rs
@@ -461,7 +461,7 @@ pub fn from_raw_parts<Dyn: ?Sized>(
     ptr: *const (),
     metadata: ObjMetadata<Dyn>,
 ) -> *const DynObj<Dyn> {
-    let metadata: usize = metadata.vtable_ptr as *const _ as usize;
+    let metadata: usize = (metadata.vtable_ptr as *const VTableHead).expose_addr();
     let inner: *const [()] = std::ptr::from_raw_parts(ptr, metadata);
     inner as *const DynObj<Dyn>
 }
@@ -475,7 +475,7 @@ pub fn from_raw_parts_mut<Dyn: ?Sized>(
     ptr: *mut (),
     metadata: ObjMetadata<Dyn>,
 ) -> *mut DynObj<Dyn> {
-    let metadata: usize = metadata.vtable_ptr as *const _ as usize;
+    let metadata: usize = (metadata.vtable_ptr as *const VTableHead).expose_addr();
     let inner: *mut [()] = std::ptr::from_raw_parts_mut(ptr, metadata);
     inner as *mut DynObj<Dyn>
 }
@@ -484,7 +484,8 @@ pub fn from_raw_parts_mut<Dyn: ?Sized>(
 #[inline]
 pub fn metadata<Dyn: ?Sized>(ptr: *const DynObj<Dyn>) -> ObjMetadata<Dyn> {
     let metadata = std::ptr::metadata(ptr);
-    let metadata = unsafe { &*(metadata as *const VTableHead) };
+    let metadata_ptr = std::ptr::from_exposed_addr(metadata as usize);
+    let metadata = unsafe { &*metadata_ptr };
     ObjMetadata {
         vtable_ptr: metadata,
         phantom: PhantomData,

--- a/utilities/fimo_ffi/src/ptr.rs
+++ b/utilities/fimo_ffi/src/ptr.rs
@@ -483,7 +483,7 @@ pub fn from_raw_parts_mut<Dyn: ?Sized>(
 /// Extracts the metadata component of the pointer.
 #[inline]
 pub fn metadata<Dyn: ?Sized>(ptr: *const DynObj<Dyn>) -> ObjMetadata<Dyn> {
-    let metadata: usize = std::ptr::metadata(ptr);
+    let metadata = std::ptr::metadata(ptr);
     unsafe { std::mem::transmute(metadata) }
 }
 

--- a/utilities/fimo_ffi/src/ptr.rs
+++ b/utilities/fimo_ffi/src/ptr.rs
@@ -461,7 +461,7 @@ pub fn from_raw_parts<Dyn: ?Sized>(
     ptr: *const (),
     metadata: ObjMetadata<Dyn>,
 ) -> *const DynObj<Dyn> {
-    let metadata: usize = unsafe { std::mem::transmute(metadata) };
+    let metadata: usize = metadata.vtable_ptr as *const _ as usize;
     let inner: *const [()] = std::ptr::from_raw_parts(ptr, metadata);
     inner as *const DynObj<Dyn>
 }
@@ -475,7 +475,7 @@ pub fn from_raw_parts_mut<Dyn: ?Sized>(
     ptr: *mut (),
     metadata: ObjMetadata<Dyn>,
 ) -> *mut DynObj<Dyn> {
-    let metadata: usize = unsafe { std::mem::transmute(metadata) };
+    let metadata: usize = metadata.vtable_ptr as *const _ as usize;
     let inner: *mut [()] = std::ptr::from_raw_parts_mut(ptr, metadata);
     inner as *mut DynObj<Dyn>
 }
@@ -484,7 +484,11 @@ pub fn from_raw_parts_mut<Dyn: ?Sized>(
 #[inline]
 pub fn metadata<Dyn: ?Sized>(ptr: *const DynObj<Dyn>) -> ObjMetadata<Dyn> {
     let metadata = std::ptr::metadata(ptr);
-    unsafe { std::mem::transmute(metadata) }
+    let metadata = unsafe { &*(metadata as *const VTableHead) };
+    ObjMetadata {
+        vtable_ptr: metadata,
+        phantom: PhantomData,
+    }
 }
 
 /// Constructs a [`RawObj<T>`] from a `*const DynObj<T>`.

--- a/utilities/fimo_ffi/src/vec.rs
+++ b/utilities/fimo_ffi/src/vec.rs
@@ -3117,7 +3117,7 @@ impl<T, A: Allocator> Iterator for IntoIter<T, A> {
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let exact = if std::mem::size_of::<T>() == 0 {
-            (self.end as usize).wrapping_sub(self.ptr as usize)
+            (self.end.addr()).wrapping_sub(self.ptr.addr())
         } else {
             unsafe { self.end.offset_from(self.ptr) as usize }
         };


### PR DESCRIPTION
Extends the tasks interface by drawing inspiration from the `parking_lot_core` crate:

* Bug fixes
* Mirror API from `parking_lot_core`
* Port synchronization primitives from `parking_lot`:
    - Mutex
    - RwLock
    - Condvar
    - Barrier