### PR TITLE
Better errors

### DIFF
--- a/ffi_library/fimo_std/include/fimo_std/array_list.h
+++ b/ffi_library/fimo_std/include/fimo_std/array_list.h
@@ -52,8 +52,8 @@ FimoArrayList fimo_array_list_new(void);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_with_capacity(FimoUSize capacity, FimoUSize elem_size, FimoUSize elem_align,
-                                        FimoArrayList *array);
+FimoResult fimo_array_list_with_capacity(FimoUSize capacity, FimoUSize elem_size, FimoUSize elem_align,
+                                         FimoArrayList *array);
 
 /**
  * Creates a new empty array with an exact capacity.
@@ -69,8 +69,8 @@ FimoError fimo_array_list_with_capacity(FimoUSize capacity, FimoUSize elem_size,
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_with_capacity_exact(FimoUSize capacity, FimoUSize elem_size, FimoUSize elem_align,
-                                              FimoArrayList *array);
+FimoResult fimo_array_list_with_capacity_exact(FimoUSize capacity, FimoUSize elem_size, FimoUSize elem_align,
+                                               FimoArrayList *array);
 
 /**
  * Frees an array.
@@ -97,8 +97,8 @@ void fimo_array_list_free(FimoArrayList *array, FimoUSize elem_size, FimoUSize e
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_reserve(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align, FimoUSize additional,
-                                  FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_reserve(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align,
+                                   FimoUSize additional, FimoArrayListMoveFunc move_func);
 
 /**
  * Reserve capacity for exactly `additional` more elements.
@@ -113,8 +113,8 @@ FimoError fimo_array_list_reserve(FimoArrayList *array, FimoUSize elem_size, Fim
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_reserve_exact(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align,
-                                        FimoUSize additional, FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_reserve_exact(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align,
+                                         FimoUSize additional, FimoArrayListMoveFunc move_func);
 
 /**
  * Resizes the array to a capacity of at least `capacity` elements.
@@ -130,9 +130,9 @@ FimoError fimo_array_list_reserve_exact(FimoArrayList *array, FimoUSize elem_siz
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_set_capacity(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align,
-                                       FimoUSize capacity, FimoArrayListMoveFunc move_func,
-                                       FimoArrayListDropFunc drop_func);
+FimoResult fimo_array_list_set_capacity(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align,
+                                        FimoUSize capacity, FimoArrayListMoveFunc move_func,
+                                        FimoArrayListDropFunc drop_func);
 
 /**
  * Resizes the array to a capacity of exactly `capacity` elements.
@@ -148,9 +148,9 @@ FimoError fimo_array_list_set_capacity(FimoArrayList *array, FimoUSize elem_size
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_set_capacity_exact(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align,
-                                             FimoUSize capacity, FimoArrayListMoveFunc move_func,
-                                             FimoArrayListDropFunc drop_func);
+FimoResult fimo_array_list_set_capacity_exact(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align,
+                                              FimoUSize capacity, FimoArrayListMoveFunc move_func,
+                                              FimoArrayListDropFunc drop_func);
 
 /**
  * Sets the number of elements contained in the array.
@@ -162,7 +162,7 @@ FimoError fimo_array_list_set_capacity_exact(FimoArrayList *array, FimoUSize ele
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_set_len(FimoArrayList *array, FimoUSize len);
+FimoResult fimo_array_list_set_len(FimoArrayList *array, FimoUSize len);
 
 /**
  * Returns whether the array is empty.
@@ -208,7 +208,7 @@ FimoUSize fimo_array_list_capacity(const FimoArrayList *array);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_peek_front(const FimoArrayList *array, FimoUSize elem_size, const void **element);
+FimoResult fimo_array_list_peek_front(const FimoArrayList *array, FimoUSize elem_size, const void **element);
 
 /**
  * Returns a pointer to the last element in the array.
@@ -221,7 +221,7 @@ FimoError fimo_array_list_peek_front(const FimoArrayList *array, FimoUSize elem_
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_peek_back(const FimoArrayList *array, FimoUSize elem_size, const void **element);
+FimoResult fimo_array_list_peek_back(const FimoArrayList *array, FimoUSize elem_size, const void **element);
 
 /**
  * Removes the first element of the array.
@@ -236,8 +236,8 @@ FimoError fimo_array_list_peek_back(const FimoArrayList *array, FimoUSize elem_s
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_pop_front(FimoArrayList *array, FimoUSize elem_size, void *element,
-                                    FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_pop_front(FimoArrayList *array, FimoUSize elem_size, void *element,
+                                     FimoArrayListMoveFunc move_func);
 
 /**
  * Removes the last element of the array.
@@ -252,8 +252,8 @@ FimoError fimo_array_list_pop_front(FimoArrayList *array, FimoUSize elem_size, v
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_pop_back(FimoArrayList *array, FimoUSize elem_size, void *element,
-                                   FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_pop_back(FimoArrayList *array, FimoUSize elem_size, void *element,
+                                    FimoArrayListMoveFunc move_func);
 
 /**
  * Returns a pointer to the element at position `index`.
@@ -267,7 +267,7 @@ FimoError fimo_array_list_pop_back(FimoArrayList *array, FimoUSize elem_size, vo
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_get(const FimoArrayList *array, FimoUSize index, FimoUSize elem_size, const void **element);
+FimoResult fimo_array_list_get(const FimoArrayList *array, FimoUSize index, FimoUSize elem_size, const void **element);
 
 /**
  * Pushes a new element to the end of the array.
@@ -284,8 +284,8 @@ FimoError fimo_array_list_get(const FimoArrayList *array, FimoUSize index, FimoU
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_push(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align, void *element,
-                               FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_push(FimoArrayList *array, FimoUSize elem_size, FimoUSize elem_align, void *element,
+                                FimoArrayListMoveFunc move_func);
 
 /**
  * Pushes a new element to the end of the array.
@@ -298,8 +298,8 @@ FimoError fimo_array_list_push(FimoArrayList *array, FimoUSize elem_size, FimoUS
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_try_push(FimoArrayList *array, FimoUSize elem_size, void *element,
-                                   FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_try_push(FimoArrayList *array, FimoUSize elem_size, void *element,
+                                    FimoArrayListMoveFunc move_func);
 
 /**
  * Inserts an element at the specified position.
@@ -320,8 +320,8 @@ FimoError fimo_array_list_try_push(FimoArrayList *array, FimoUSize elem_size, vo
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_insert(FimoArrayList *array, FimoUSize index, FimoUSize elem_size, FimoUSize elem_align,
-                                 void *element, FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_insert(FimoArrayList *array, FimoUSize index, FimoUSize elem_size, FimoUSize elem_align,
+                                  void *element, FimoArrayListMoveFunc move_func);
 
 /**
  * Inserts an element at the specified position.
@@ -339,8 +339,8 @@ FimoError fimo_array_list_insert(FimoArrayList *array, FimoUSize index, FimoUSiz
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_try_insert(FimoArrayList *array, FimoUSize index, FimoUSize elem_size, void *element,
-                                     FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_try_insert(FimoArrayList *array, FimoUSize index, FimoUSize elem_size, void *element,
+                                      FimoArrayListMoveFunc move_func);
 
 /**
  * Removes the element at the given position from the array.
@@ -359,8 +359,8 @@ FimoError fimo_array_list_try_insert(FimoArrayList *array, FimoUSize index, Fimo
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_remove(FimoArrayList *array, FimoUSize index, FimoUSize elem_size, void *element,
-                                 FimoArrayListMoveFunc move_func);
+FimoResult fimo_array_list_remove(FimoArrayList *array, FimoUSize index, FimoUSize elem_size, void *element,
+                                  FimoArrayListMoveFunc move_func);
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/context.h
+++ b/ffi_library/fimo_std/include/fimo_std/context.h
@@ -59,7 +59,7 @@ typedef struct FimoBaseStructOut {
  * available to us.
  */
 typedef struct FimoContextVTableHeader {
-    FimoError (*check_version)(void *, const FimoVersion *);
+    FimoResult (*check_version)(void *, const FimoVersion *);
 } FimoContextVTableHeader;
 
 /**
@@ -87,7 +87,7 @@ typedef struct FimoContextVTableV0 {
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_context_init(const FimoBaseStructIn **options, FimoContext *context);
+FimoResult fimo_context_init(const FimoBaseStructIn **options, FimoContext *context);
 
 /**
  * Checks the compatibility of the context version.
@@ -103,7 +103,7 @@ FimoError fimo_context_init(const FimoBaseStructIn **options, FimoContext *conte
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_context_check_version(FimoContext context);
+FimoResult fimo_context_check_version(FimoContext context);
 
 /**
  * Acquires a reference to the context.

--- a/ffi_library/fimo_std/include/fimo_std/error.h
+++ b/ffi_library/fimo_std/include/fimo_std/error.h
@@ -532,10 +532,7 @@ static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_error_code(FimoErrorCode c
     if (code > FIMO_ERROR_CODE_MAX) {
         return FIMO_IMPL_RESULT_INVALID_ERROR;
     }
-    FIMO_PRAGMA_MSVC(warning(push))
-    FIMO_PRAGMA_MSVC(warning(disable : 4306))
-    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)code, .vtable = &FIMO_IMPL_RESULT_ERROR_CODE_VTABLE};
-    FIMO_PRAGMA_MSVC(warning(pop))
+    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)(intptr_t)code, .vtable = &FIMO_IMPL_RESULT_ERROR_CODE_VTABLE};
 }
 
 /**
@@ -547,10 +544,8 @@ static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_error_code(FimoErrorCode c
  */
 FIMO_MUST_USE
 static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_system_error_code(FimoSystemErrorCode code) {
-    FIMO_PRAGMA_MSVC(warning(push))
-    FIMO_PRAGMA_MSVC(warning(disable : 4312))
-    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)code, .vtable = &FIMO_IMPL_RESULT_SYSTEM_ERROR_CODE_VTABLE};
-    FIMO_PRAGMA_MSVC(warning(pop))
+    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)(intptr_t)code,
+                                        .vtable = &FIMO_IMPL_RESULT_SYSTEM_ERROR_CODE_VTABLE};
 }
 
 /**
@@ -560,7 +555,6 @@ static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_system_error_code(FimoSyst
  *
  * @return Whether the result is an error.
  */
-FIMO_MUST_USE
 static FIMO_INLINE_ALWAYS bool fimo_result_is_error(FimoResult result) { return result.vtable != NULL; }
 
 /**
@@ -570,7 +564,6 @@ static FIMO_INLINE_ALWAYS bool fimo_result_is_error(FimoResult result) { return 
  *
  * @return Whether the result is not an error.
  */
-FIMO_MUST_USE
 static FIMO_INLINE_ALWAYS bool fimo_result_is_ok(FimoResult result) { return result.vtable == NULL; }
 
 /**
@@ -580,7 +573,6 @@ static FIMO_INLINE_ALWAYS bool fimo_result_is_ok(FimoResult result) { return res
  *
  * @param result result to release
  */
-FIMO_MUST_USE
 static FIMO_INLINE_ALWAYS void fimo_result_release(FimoResult result) {
     if (fimo_result_is_error(result) && result.vtable->v0.release) {
         result.vtable->v0.release(result.data);

--- a/ffi_library/fimo_std/include/fimo_std/error.h
+++ b/ffi_library/fimo_std/include/fimo_std/error.h
@@ -1,240 +1,628 @@
 #ifndef FIMO_ERROR_H
 #define FIMO_ERROR_H
 
+#include <assert.h>
+#include <stdalign.h>
 #include <stdbool.h>
 
 #include <fimo_std/utils.h>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#define FIMO_IGNORE_(expr, var)                                                                                        \
-    do {                                                                                                               \
-        FimoError var = (expr);                                                                                        \
-        (void)var;                                                                                                     \
-    }                                                                                                                  \
-    while (0)
+/**
+ * Upper range (inclusive) of the valid error codes.
+ */
+#define FIMO_ERROR_CODE_MAX FIMO_ERROR_CODE_XFULL
 
 /**
- * Ignores a `FimoError` result.
- *
- * Many functions are annotated with the `FIMO_MUST_USE`
- * attribute, which makes the compiler emit a warning,
- * in case the result is not used. Most compilers allow
- * suppressing the warning by using `(void)expr`, but
- * this does not work in GCC.
+ * Ignores a `FimoResult` result.
  *
  * @param EXPR expression to ignore
  */
-#define FIMO_IGNORE(EXPR) FIMO_IGNORE_(EXPR, FIMO_VAR(_fimo_ignored))
+#define FIMO_RESULT_IGNORE(EXPR) fimo_result_release((EXPR))
+
+/**
+ * Checks whether a `FimoResult` contains an error.
+ *
+ * @param EXPR expression to check
+ */
+#define FIMO_RESULT_IS_ERROR(EXPR) fimo_result_is_error((EXPR))
+
+/**
+ * Checks whether a `FimoResult` does not contain an error.
+ *
+ * @param EXPR expression to check
+ */
+#define FIMO_RESULT_IS_OK(EXPR) fimo_result_is_ok((EXPR))
+
+/**
+ * Constructs a `FimoResult` from a static string.
+ *
+ * @param CODE error code
+ */
+#define FIMO_RESULT_FROM_STRING(ERROR) fimo_result_from_static_string(ERROR)
+
+/**
+ * Constructs a `FimoResult` from a dynamic string.
+ *
+ * @param CODE error code
+ */
+#define FIMO_RESULT_FROM_DYNAMIC_STRING(ERROR) fimo_result_from_dynamic_string(ERROR)
+
+/**
+ * Constructs a `FimoResult` from a `FimoErrorCode`.
+ *
+ * @param CODE error code
+ */
+#define FIMO_RESULT_FROM_ERROR_CODE(CODE) fimo_result_from_error_code(CODE)
+
+/**
+ * Constructs a `FimoResult` from a `FimoSystemErrorCode`.
+ *
+ * @param CODE error code
+ */
+#define FIMO_RESULT_FROM_SYSTEM_ERROR_CODE(CODE) fimo_result_from_system_error_code(CODE)
+
+#define FIMO_EOK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_OK)
+#define FIMO_E2BIG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_2BIG)
+#define FIMO_EACCES FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ACCES)
+#define FIMO_EADDRINUSE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ADDRINUSE)
+#define FIMO_EADDRNOTAVAIL FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ADDRNOTAVAIL)
+#define FIMO_EAFNOSUPPORT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_AFNOSUPPORT)
+#define FIMO_EAGAIN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_AGAIN)
+#define FIMO_EALREADY FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ALREADY)
+#define FIMO_EBADE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BADE)
+#define FIMO_EBADF FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BADF)
+#define FIMO_EBADFD FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BADFD)
+#define FIMO_EBADMSG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BADMSG)
+#define FIMO_EBADR FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BADR)
+#define FIMO_EBADRQC FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BADRQC)
+#define FIMO_EBADSLT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BADSLT)
+#define FIMO_EBUSY FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_BUSY)
+#define FIMO_ECANCELED FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_CANCELED)
+#define FIMO_ECHILD FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_CHILD)
+#define FIMO_ECHRNG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_CHRNG)
+#define FIMO_ECOMM FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_COMM)
+#define FIMO_ECONNABORTED FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_CONNABORTED)
+#define FIMO_ECONNREFUSED FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_CONNREFUSED)
+#define FIMO_ECONNRESET FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_CONNRESET)
+#define FIMO_EDEADLK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_DEADLK)
+#define FIMO_EDEADLOCK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_DEADLOCK)
+#define FIMO_EDESTADDRREQ FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_DESTADDRREQ)
+#define FIMO_EDOM FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_DOM)
+#define FIMO_EDQUOT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_DQUOT)
+#define FIMO_EEXIST FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_EXIST)
+#define FIMO_EFAULT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_FAULT)
+#define FIMO_EFBIG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_FBIG)
+#define FIMO_EHOSTDOWN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_HOSTDOWN)
+#define FIMO_EHOSTUNREACH FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_HOSTUNREACH)
+#define FIMO_EHWPOISON FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_HWPOISON)
+#define FIMO_EIDRM FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_IDRM)
+#define FIMO_EILSEQ FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ILSEQ)
+#define FIMO_EINPROGRESS FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_INPROGRESS)
+#define FIMO_EINTR FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_INTR)
+#define FIMO_EINVAL FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_INVAL)
+#define FIMO_EIO FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_IO)
+#define FIMO_EISCONN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ISCONN)
+#define FIMO_EISDIR FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ISDIR)
+#define FIMO_EISNAM FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ISNAM)
+#define FIMO_EKEYEXPIRED FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_KEYEXPIRED)
+#define FIMO_EKEYREJECTED FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_KEYREJECTED)
+#define FIMO_EKEYREVOKED FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_KEYREVOKED)
+#define FIMO_EL2HLT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_L2HLT)
+#define FIMO_EL2NSYNC FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_L2NSYNC)
+#define FIMO_EL3HLT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_L3HLT)
+#define FIMO_EL3RST FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_L3RST)
+#define FIMO_ELIBACC FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_LIBACC)
+#define FIMO_ELIBBAD FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_LIBBAD)
+#define FIMO_ELIBMAX FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_LIBMAX)
+#define FIMO_ELIBSCN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_LIBSCN)
+#define FIMO_ELIBEXEC FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_LIBEXEC)
+#define FIMO_ELNRNG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_LNRNG)
+#define FIMO_ELOOP FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_LOOP)
+#define FIMO_EMEDIUMTYPE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_MEDIUMTYPE)
+#define FIMO_EMFILE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_MFILE)
+#define FIMO_EMLINK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_MLINK)
+#define FIMO_EMSGSIZE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_MSGSIZE)
+#define FIMO_EMULTIHOP FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_MULTIHOP)
+#define FIMO_ENAMETOOLONG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NAMETOOLONG)
+#define FIMO_ENETDOWN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NETDOWN)
+#define FIMO_ENETRESET FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NETRESET)
+#define FIMO_ENETUNREACH FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NETUNREACH)
+#define FIMO_ENFILE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NFILE)
+#define FIMO_ENOANO FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOANO)
+#define FIMO_ENOBUFS FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOBUFS)
+#define FIMO_ENODATA FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NODATA)
+#define FIMO_ENODEV FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NODEV)
+#define FIMO_ENOENT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOENT)
+#define FIMO_ENOEXEC FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOEXEC)
+#define FIMO_ENOKEY FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOKEY)
+#define FIMO_ENOLCK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOLCK)
+#define FIMO_ENOLINK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOLINK)
+#define FIMO_ENOMEDIUM FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOMEDIUM)
+#define FIMO_ENOMEM FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOMEM)
+#define FIMO_ENOMSG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOMSG)
+#define FIMO_ENONET FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NONET)
+#define FIMO_ENOPKG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOPKG)
+#define FIMO_ENOPROTOOPT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOPROTOOPT)
+#define FIMO_ENOSPC FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOSPC)
+#define FIMO_ENOSR FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOSR)
+#define FIMO_ENOSTR FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOSTR)
+#define FIMO_ENOSYS FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOSYS)
+#define FIMO_ENOTBLK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTBLK)
+#define FIMO_ENOTCONN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTCONN)
+#define FIMO_ENOTDIR FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTDIR)
+#define FIMO_ENOTEMPTY FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTEMPTY)
+#define FIMO_ENOTRECOVERABLE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTRECOVERABLE)
+#define FIMO_ENOTSOCK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTSOCK)
+#define FIMO_ENOTSUP FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTSUP)
+#define FIMO_ENOTTY FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTTY)
+#define FIMO_ENOTUNIQ FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NOTUNIQ)
+#define FIMO_ENXIO FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_NXIO)
+#define FIMO_EOPNOTSUPP FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_OPNOTSUPP)
+#define FIMO_EOVERFLOW FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_OVERFLOW)
+#define FIMO_EOWNERDEAD FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_OWNERDEAD)
+#define FIMO_EPERM FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_PERM)
+#define FIMO_EPFNOSUPPORT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_PFNOSUPPORT)
+#define FIMO_EPIPE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_PIPE)
+#define FIMO_EPROTO FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_PROTO)
+#define FIMO_EPROTONOSUPPORT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_PROTONOSUPPORT)
+#define FIMO_EPROTOTYPE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_PROTOTYPE)
+#define FIMO_ERANGE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_RANGE)
+#define FIMO_EREMCHG FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_REMCHG)
+#define FIMO_EREMOTE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_REMOTE)
+#define FIMO_EREMOTEIO FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_REMOTEIO)
+#define FIMO_ERESTART FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_RESTART)
+#define FIMO_ERFKILL FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_RFKILL)
+#define FIMO_EROFS FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_ROFS)
+#define FIMO_ESHUTDOWN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_SHUTDOWN)
+#define FIMO_ESPIPE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_SPIPE)
+#define FIMO_ESOCKTNOSUPPORT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_SOCKTNOSUPPORT)
+#define FIMO_ESRCH FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_SRCH)
+#define FIMO_ESTALE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_STALE)
+#define FIMO_ESTRPIPE FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_STRPIPE)
+#define FIMO_ETIME FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_TIME)
+#define FIMO_ETIMEDOUT FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_TIMEDOUT)
+#define FIMO_ETOOMANYREFS FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_TOOMANYREFS)
+#define FIMO_ETXTBSY FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_TXTBSY)
+#define FIMO_EUCLEAN FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_UCLEAN)
+#define FIMO_EUNATCH FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_UNATCH)
+#define FIMO_EUSERS FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_USERS)
+#define FIMO_EWOULDBLOCK FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_WOULDBLOCK)
+#define FIMO_EXDEV FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_XDEV)
+#define FIMO_EXFULL FIMO_RESULT_FROM_ERROR_CODE(FIMO_ERROR_CODE_XFULL)
 
 /**
  * Posix error codes.
  */
-typedef enum FimoError {
-    FIMO_EOK = 0, /* Operation completed successfully */
-    FIMO_E2BIG, /* Argument list too long */
-    FIMO_EACCES, /* Permission denied */
-    FIMO_EADDRINUSE, /* Address already in use */
-    FIMO_EADDRNOTAVAIL, /* Address not available */
-    FIMO_EAFNOSUPPORT, /* Address family not supported */
-    FIMO_EAGAIN, /* Resource temporarily unavailable */
-    FIMO_EALREADY, /* Connection already in progress */
-    FIMO_EBADE, /* Invalid exchange */
-    FIMO_EBADF, /* Bad file descriptor */
-    FIMO_EBADFD, /* File descriptor in bad state */
-    FIMO_EBADMSG, /* Bad message */
-    FIMO_EBADR, /* Invalid request descriptor */
-    FIMO_EBADRQC, /* Invalid request code */
-    FIMO_EBADSLT, /* Invalid slot */
-    FIMO_EBUSY, /* Device or resource busy */
-    FIMO_ECANCELED, /* Operation canceled */
-    FIMO_ECHILD, /* No child processes */
-    FIMO_ECHRNG, /* Channel number out of range */
-    FIMO_ECOMM, /* Communication error on send */
-    FIMO_ECONNABORTED, /* Connection aborted */
-    FIMO_ECONNREFUSED, /* Connection refused */
-    FIMO_ECONNRESET, /* Connection reset */
-    FIMO_EDEADLK, /* Resource deadlock avoided */
-    FIMO_EDEADLOCK, /* File locking deadlock error (or Resource deadlock avoided) */
-    FIMO_EDESTADDRREQ, /* Destination address required */
-    FIMO_EDOM, /* Mathematics argument out of domain of function */
-    FIMO_EDQUOT, /* Disk quota exceeded */
-    FIMO_EEXIST, /* File exists */
-    FIMO_EFAULT, /* Bad address */
-    FIMO_EFBIG, /* File too large */
-    FIMO_EHOSTDOWN, /* Host is down */
-    FIMO_EHOSTUNREACH, /* Host is unreachable */
-    FIMO_EHWPOISON, /* Memory page has hardware error */
-    FIMO_EIDRM, /* Identifier removed */
-    FIMO_EILSEQ, /* Invalid or incomplete multibyte or wide character */
-    FIMO_EINPROGRESS, /* Operation in progress */
-    FIMO_EINTR, /* Interrupted function call */
-    FIMO_EINVAL, /* Invalid argument */
-    FIMO_EIO, /* Input/output error */
-    FIMO_EISCONN, /* Socket is connected */
-    FIMO_EISDIR, /* Is a directory */
-    FIMO_EISNAM, /* Is a named type file */
-    FIMO_EKEYEXPIRED, /* Key has expired */
-    FIMO_EKEYREJECTED, /* Key was rejected by service */
-    FIMO_EKEYREVOKED, /* Key has been revoked */
-    FIMO_EL2HLT, /* Level 2 halted */
-    FIMO_EL2NSYNC, /* Level 2 not synchronized */
-    FIMO_EL3HLT, /* Level 3 halted */
-    FIMO_EL3RST, /* Level 3 reset */
-    FIMO_ELIBACC, /* Cannot access a needed shared library */
-    FIMO_ELIBBAD, /* Accessing a corrupted shared library */
-    FIMO_ELIBMAX, /* Attempting to link in too many shared libraries */
-    FIMO_ELIBSCN, /* .lib section in a.out corrupted */
-    FIMO_ELIBEXEC, /* Cannot exec a shared library directly */
-    FIMO_ELNRNG, /* Link number out of range */
-    FIMO_ELOOP, /* Too many levels of symbolic links */
-    FIMO_EMEDIUMTYPE, /* Wrong medium type */
-    FIMO_EMFILE, /* Too many open files */
-    FIMO_EMLINK, /* Too many links */
-    FIMO_EMSGSIZE, /* Message too long */
-    FIMO_EMULTIHOP, /* Multihop attempted */
-    FIMO_ENAMETOOLONG, /* Filename too long */
-    FIMO_ENETDOWN, /* Network is down */
-    FIMO_ENETRESET, /* Connection aborted by network */
-    FIMO_ENETUNREACH, /* Network unreachable */
-    FIMO_ENFILE, /* Too many open files in system */
-    FIMO_ENOANO, /* No anode */
-    FIMO_ENOBUFS, /* No buffer space available */
-    FIMO_ENODATA, /* The named attribute does not exist, or the process has no access to this attribute */
-    FIMO_ENODEV, /* No such device */
-    FIMO_ENOENT, /* No such file or directory */
-    FIMO_ENOEXEC, /* Exec format error */
-    FIMO_ENOKEY, /* Required key not available */
-    FIMO_ENOLCK, /* No locks available */
-    FIMO_ENOLINK, /* Link has been severed */
-    FIMO_ENOMEDIUM, /* No medium found */
-    FIMO_ENOMEM, /* Not enough space/cannot allocate memory */
-    FIMO_ENOMSG, /* No message of the desired type */
-    FIMO_ENONET, /* Machine is not on the network */
-    FIMO_ENOPKG, /* Package not installed */
-    FIMO_ENOPROTOOPT, /* Protocol not available */
-    FIMO_ENOSPC, /* No space left on device */
-    FIMO_ENOSR, /* No STREAM resources */
-    FIMO_ENOSTR, /* Not a STREAM */
-    FIMO_ENOSYS, /* Function not implemented */
-    FIMO_ENOTBLK, /* Block device required */
-    FIMO_ENOTCONN, /* The socket is not connected */
-    FIMO_ENOTDIR, /* Not a directory */
-    FIMO_ENOTEMPTY, /* Directory not empty */
-    FIMO_ENOTRECOVERABLE, /* State not recoverable */
-    FIMO_ENOTSOCK, /* Not a socket */
-    FIMO_ENOTSUP, /* Operation not supported */
-    FIMO_ENOTTY, /* Inappropriate I/O control operation */
-    FIMO_ENOTUNIQ, /* Name not unique on network */
-    FIMO_ENXIO, /* No such device or address */
-    FIMO_EOPNOTSUPP, /* Operation not supported on socket */
-    FIMO_EOVERFLOW, /* Value too large to be stored in data type */
-    FIMO_EOWNERDEAD, /* Owner died */
-    FIMO_EPERM, /* Operation not permitted */
-    FIMO_EPFNOSUPPORT, /* Protocol family not supported */
-    FIMO_EPIPE, /* Broken pipe */
-    FIMO_EPROTO, /* Protocol error */
-    FIMO_EPROTONOSUPPORT, /* Protocol not supported */
-    FIMO_EPROTOTYPE, /* Protocol wrong type for socket */
-    FIMO_ERANGE, /* Result too large */
-    FIMO_EREMCHG, /* Remote address changed */
-    FIMO_EREMOTE, /* Object is remote */
-    FIMO_EREMOTEIO, /* Remote I/O error */
-    FIMO_ERESTART, /* Interrupted system call should be restarted */
-    FIMO_ERFKILL, /* Operation not possible due to RF-kill */
-    FIMO_EROFS, /* Read-only filesystem */
-    FIMO_ESHUTDOWN, /* Cannot send after transport endpoint shutdown */
-    FIMO_ESPIPE, /* Invalid seek */
-    FIMO_ESOCKTNOSUPPORT, /* Socket type not supported */
-    FIMO_ESRCH, /* No such process */
-    FIMO_ESTALE, /* Stale file handle */
-    FIMO_ESTRPIPE, /* Streams pipe error */
-    FIMO_ETIME, /* Timer expired */
-    FIMO_ETIMEDOUT, /* Connection timed out */
-    FIMO_ETOOMANYREFS, /* Too many references: cannot splice */
-    FIMO_ETXTBSY, /* Text file busy */
-    FIMO_EUCLEAN, /* Structure needs cleaning */
-    FIMO_EUNATCH, /* Protocol driver not attached */
-    FIMO_EUSERS, /* Too many users */
-    FIMO_EWOULDBLOCK, /* Operation would block */
-    FIMO_EXDEV, /* Invalid cross-device link */
-    FIMO_EXFULL, /* Exchange full */
-    FIMO_EUNKNOWN, /* Unknown error */
-} FimoError;
+typedef enum FimoErrorCode {
+    FIMO_ERROR_CODE_OK = 0, /* Operation completed successfully */
+    FIMO_ERROR_CODE_2BIG, /* Argument list too long */
+    FIMO_ERROR_CODE_ACCES, /* Permission denied */
+    FIMO_ERROR_CODE_ADDRINUSE, /* Address already in use */
+    FIMO_ERROR_CODE_ADDRNOTAVAIL, /* Address not available */
+    FIMO_ERROR_CODE_AFNOSUPPORT, /* Address family not supported */
+    FIMO_ERROR_CODE_AGAIN, /* Resource temporarily unavailable */
+    FIMO_ERROR_CODE_ALREADY, /* Connection already in progress */
+    FIMO_ERROR_CODE_BADE, /* Invalid exchange */
+    FIMO_ERROR_CODE_BADF, /* Bad file descriptor */
+    FIMO_ERROR_CODE_BADFD, /* File descriptor in bad state */
+    FIMO_ERROR_CODE_BADMSG, /* Bad message */
+    FIMO_ERROR_CODE_BADR, /* Invalid request descriptor */
+    FIMO_ERROR_CODE_BADRQC, /* Invalid request code */
+    FIMO_ERROR_CODE_BADSLT, /* Invalid slot */
+    FIMO_ERROR_CODE_BUSY, /* Device or resource busy */
+    FIMO_ERROR_CODE_CANCELED, /* Operation canceled */
+    FIMO_ERROR_CODE_CHILD, /* No child processes */
+    FIMO_ERROR_CODE_CHRNG, /* Channel number out of range */
+    FIMO_ERROR_CODE_COMM, /* Communication error on send */
+    FIMO_ERROR_CODE_CONNABORTED, /* Connection aborted */
+    FIMO_ERROR_CODE_CONNREFUSED, /* Connection refused */
+    FIMO_ERROR_CODE_CONNRESET, /* Connection reset */
+    FIMO_ERROR_CODE_DEADLK, /* Resource deadlock avoided */
+    FIMO_ERROR_CODE_DEADLOCK, /* File locking deadlock error (or Resource deadlock avoided) */
+    FIMO_ERROR_CODE_DESTADDRREQ, /* Destination address required */
+    FIMO_ERROR_CODE_DOM, /* Mathematics argument out of domain of function */
+    FIMO_ERROR_CODE_DQUOT, /* Disk quota exceeded */
+    FIMO_ERROR_CODE_EXIST, /* File exists */
+    FIMO_ERROR_CODE_FAULT, /* Bad address */
+    FIMO_ERROR_CODE_FBIG, /* File too large */
+    FIMO_ERROR_CODE_HOSTDOWN, /* Host is down */
+    FIMO_ERROR_CODE_HOSTUNREACH, /* Host is unreachable */
+    FIMO_ERROR_CODE_HWPOISON, /* Memory page has hardware error */
+    FIMO_ERROR_CODE_IDRM, /* Identifier removed */
+    FIMO_ERROR_CODE_ILSEQ, /* Invalid or incomplete multibyte or wide character */
+    FIMO_ERROR_CODE_INPROGRESS, /* Operation in progress */
+    FIMO_ERROR_CODE_INTR, /* Interrupted function call */
+    FIMO_ERROR_CODE_INVAL, /* Invalid argument */
+    FIMO_ERROR_CODE_IO, /* Input/output error */
+    FIMO_ERROR_CODE_ISCONN, /* Socket is connected */
+    FIMO_ERROR_CODE_ISDIR, /* Is a directory */
+    FIMO_ERROR_CODE_ISNAM, /* Is a named type file */
+    FIMO_ERROR_CODE_KEYEXPIRED, /* Key has expired */
+    FIMO_ERROR_CODE_KEYREJECTED, /* Key was rejected by service */
+    FIMO_ERROR_CODE_KEYREVOKED, /* Key has been revoked */
+    FIMO_ERROR_CODE_L2HLT, /* Level 2 halted */
+    FIMO_ERROR_CODE_L2NSYNC, /* Level 2 not synchronized */
+    FIMO_ERROR_CODE_L3HLT, /* Level 3 halted */
+    FIMO_ERROR_CODE_L3RST, /* Level 3 reset */
+    FIMO_ERROR_CODE_LIBACC, /* Cannot access a needed shared library */
+    FIMO_ERROR_CODE_LIBBAD, /* Accessing a corrupted shared library */
+    FIMO_ERROR_CODE_LIBMAX, /* Attempting to link in too many shared libraries */
+    FIMO_ERROR_CODE_LIBSCN, /* .lib section in a.out corrupted */
+    FIMO_ERROR_CODE_LIBEXEC, /* Cannot exec a shared library directly */
+    FIMO_ERROR_CODE_LNRNG, /* Link number out of range */
+    FIMO_ERROR_CODE_LOOP, /* Too many levels of symbolic links */
+    FIMO_ERROR_CODE_MEDIUMTYPE, /* Wrong medium type */
+    FIMO_ERROR_CODE_MFILE, /* Too many open files */
+    FIMO_ERROR_CODE_MLINK, /* Too many links */
+    FIMO_ERROR_CODE_MSGSIZE, /* Message too long */
+    FIMO_ERROR_CODE_MULTIHOP, /* Multihop attempted */
+    FIMO_ERROR_CODE_NAMETOOLONG, /* Filename too long */
+    FIMO_ERROR_CODE_NETDOWN, /* Network is down */
+    FIMO_ERROR_CODE_NETRESET, /* Connection aborted by network */
+    FIMO_ERROR_CODE_NETUNREACH, /* Network unreachable */
+    FIMO_ERROR_CODE_NFILE, /* Too many open files in system */
+    FIMO_ERROR_CODE_NOANO, /* No anode */
+    FIMO_ERROR_CODE_NOBUFS, /* No buffer space available */
+    FIMO_ERROR_CODE_NODATA, /* The named attribute does not exist, or the process has no access to this attribute */
+    FIMO_ERROR_CODE_NODEV, /* No such device */
+    FIMO_ERROR_CODE_NOENT, /* No such file or directory */
+    FIMO_ERROR_CODE_NOEXEC, /* Exec format error */
+    FIMO_ERROR_CODE_NOKEY, /* Required key not available */
+    FIMO_ERROR_CODE_NOLCK, /* No locks available */
+    FIMO_ERROR_CODE_NOLINK, /* Link has been severed */
+    FIMO_ERROR_CODE_NOMEDIUM, /* No medium found */
+    FIMO_ERROR_CODE_NOMEM, /* Not enough space/cannot allocate memory */
+    FIMO_ERROR_CODE_NOMSG, /* No message of the desired type */
+    FIMO_ERROR_CODE_NONET, /* Machine is not on the network */
+    FIMO_ERROR_CODE_NOPKG, /* Package not installed */
+    FIMO_ERROR_CODE_NOPROTOOPT, /* Protocol not available */
+    FIMO_ERROR_CODE_NOSPC, /* No space left on device */
+    FIMO_ERROR_CODE_NOSR, /* No STREAM resources */
+    FIMO_ERROR_CODE_NOSTR, /* Not a STREAM */
+    FIMO_ERROR_CODE_NOSYS, /* Function not implemented */
+    FIMO_ERROR_CODE_NOTBLK, /* Block device required */
+    FIMO_ERROR_CODE_NOTCONN, /* The socket is not connected */
+    FIMO_ERROR_CODE_NOTDIR, /* Not a directory */
+    FIMO_ERROR_CODE_NOTEMPTY, /* Directory not empty */
+    FIMO_ERROR_CODE_NOTRECOVERABLE, /* State not recoverable */
+    FIMO_ERROR_CODE_NOTSOCK, /* Not a socket */
+    FIMO_ERROR_CODE_NOTSUP, /* Operation not supported */
+    FIMO_ERROR_CODE_NOTTY, /* Inappropriate I/O control operation */
+    FIMO_ERROR_CODE_NOTUNIQ, /* Name not unique on network */
+    FIMO_ERROR_CODE_NXIO, /* No such device or address */
+    FIMO_ERROR_CODE_OPNOTSUPP, /* Operation not supported on socket */
+    FIMO_ERROR_CODE_OVERFLOW, /* Value too large to be stored in data type */
+    FIMO_ERROR_CODE_OWNERDEAD, /* Owner died */
+    FIMO_ERROR_CODE_PERM, /* Operation not permitted */
+    FIMO_ERROR_CODE_PFNOSUPPORT, /* Protocol family not supported */
+    FIMO_ERROR_CODE_PIPE, /* Broken pipe */
+    FIMO_ERROR_CODE_PROTO, /* Protocol error */
+    FIMO_ERROR_CODE_PROTONOSUPPORT, /* Protocol not supported */
+    FIMO_ERROR_CODE_PROTOTYPE, /* Protocol wrong type for socket */
+    FIMO_ERROR_CODE_RANGE, /* Result too large */
+    FIMO_ERROR_CODE_REMCHG, /* Remote address changed */
+    FIMO_ERROR_CODE_REMOTE, /* Object is remote */
+    FIMO_ERROR_CODE_REMOTEIO, /* Remote I/O error */
+    FIMO_ERROR_CODE_RESTART, /* Interrupted system call should be restarted */
+    FIMO_ERROR_CODE_RFKILL, /* Operation not possible due to RF-kill */
+    FIMO_ERROR_CODE_ROFS, /* Read-only filesystem */
+    FIMO_ERROR_CODE_SHUTDOWN, /* Cannot send after transport endpoint shutdown */
+    FIMO_ERROR_CODE_SPIPE, /* Invalid seek */
+    FIMO_ERROR_CODE_SOCKTNOSUPPORT, /* Socket type not supported */
+    FIMO_ERROR_CODE_SRCH, /* No such process */
+    FIMO_ERROR_CODE_STALE, /* Stale file handle */
+    FIMO_ERROR_CODE_STRPIPE, /* Streams pipe error */
+    FIMO_ERROR_CODE_TIME, /* Timer expired */
+    FIMO_ERROR_CODE_TIMEDOUT, /* Connection timed out */
+    FIMO_ERROR_CODE_TOOMANYREFS, /* Too many references: cannot splice */
+    FIMO_ERROR_CODE_TXTBSY, /* Text file busy */
+    FIMO_ERROR_CODE_UCLEAN, /* Structure needs cleaning */
+    FIMO_ERROR_CODE_UNATCH, /* Protocol driver not attached */
+    FIMO_ERROR_CODE_USERS, /* Too many users */
+    FIMO_ERROR_CODE_WOULDBLOCK, /* Operation would block */
+    FIMO_ERROR_CODE_XDEV, /* Invalid cross-device link */
+    FIMO_ERROR_CODE_XFULL, /* Exchange full */
+} FimoErrorCode;
 
 /**
- * Upper range (inclusive) of the valid error codes.
+ * A system error code.
  */
-#define FIMO_MAX_ERROR FIMO_EUNKNOWN
+#ifdef _WIN32
+typedef DWORD FimoSystemErrorCode;
+#else
+typedef int FimoSystemErrorCode;
+#endif
+
+static_assert(sizeof(FimoSystemErrorCode) <= sizeof(void *), "FimoSystemErrorCode size too large");
+static_assert(alignof(FimoSystemErrorCode) <= alignof(void *), "FimoSystemErrorCode alignment too large");
 
 /**
- * Checks if an error number is valid.
- *
- * @param errnum error number
- *
- * @return Error number is an error
+ * An owned string returned from a `FimoResult`.
  */
-#define FIMO_IS_VALID_ERROR(errnum) (((errnum) >= FIMO_EOK) && ((errnum) <= FIMO_MAX_ERROR))
+typedef struct FimoResultString {
+    const char *str;
+    void (*release)(const char *str);
+} FimoResultString;
 
 /**
- * Checks if an error number represents an error.
+ * Core VTable of a `FimoResult`.
  *
- * @param errnum error number
- *
- * @return Error number is valid.
+ * Changing the VTable is a breaking change.
  */
-#define FIMO_IS_ERROR(errnum) (((errnum) > FIMO_EOK) && FIMO_IS_VALID_ERROR(errnum))
+typedef struct FimoResultVTableV0 {
+    void (*release)(void *);
+    FimoResultString (*error_name)(void *);
+    FimoResultString (*error_description)(void *);
+} FimoResultVTableV0;
 
 /**
- * Get the name of the error.
+ * VTable of a `FimoResult`.
+ */
+typedef struct FimoResultVTable {
+    FimoResultVTableV0 v0;
+} FimoResultVTable;
+
+/**
+ * Status of an operation.
+ */
+typedef struct FimoResult {
+    void *data;
+    const FimoResultVTable *vtable;
+} FimoResult;
+
+/**
+ * VTable for a `FimoResult` containing a static string.
+ */
+FIMO_EXPORT
+extern const FimoResultVTable FIMO_IMPL_RESULT_STATIC_STRING_VTABLE;
+
+/**
+ * VTable for a `FimoResult` containing a dynamic string.
+ */
+FIMO_EXPORT
+extern const FimoResultVTable FIMO_IMPL_RESULT_DYNAMIC_STRING_VTABLE;
+
+/**
+ * VTable for a `FimoResult` containing a `FimoErrorCode`.
+ */
+FIMO_EXPORT
+extern const FimoResultVTable FIMO_IMPL_RESULT_ERROR_CODE_VTABLE;
+
+/**
+ * VTable for a `FimoResult` containing a `FimoSystemErrorCode`.
+ */
+FIMO_EXPORT
+extern const FimoResultVTable FIMO_IMPL_RESULT_SYSTEM_ERROR_CODE_VTABLE;
+
+/**
+ * A result indicating that no error occurred.
+ */
+FIMO_EXPORT
+extern const FimoResult FIMO_IMPL_RESULT_OK;
+
+/**
+ * A result indicating the failed construction of a `FimoResult`.
+ */
+FIMO_EXPORT
+extern const FimoResult FIMO_IMPL_RESULT_INVALID_ERROR;
+
+/**
+ * Name of the `FIMO_IMPL_RESULT_OK` result.
+ */
+FIMO_EXPORT
+extern const FimoResultString FIMO_IMPL_RESULT_OK_NAME;
+
+/**
+ * Description of the `FIMO_IMPL_RESULT_OK` result.
+ */
+FIMO_EXPORT
+extern const FimoResultString FIMO_IMPL_RESULT_OK_DESCRIPTION;
+
+/**
+ * Get the name of the error code.
  *
- * @param errnum the error number
- * @param err optional error value
+ * In case of an unknown error this returns `"FIMO_ERROR_CODE_UNKNOWN"`.
  *
- * The success of this call are written into `err` if it is not `NULL`.
- * In case of an error this returns `"Unknown error number"`.
+ * @param errnum the error code
  *
  * @return The name of the error.
- *
- * @error `FIMO_EOK`: Operation was successful.
- * @error `FIMO_EINVAL`: The value of `errnum` is not a valid error number.
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-const char *fimo_strerrorname(FimoError errnum, FimoError *err);
+const char *fimo_error_code_name(FimoErrorCode errnum);
 
 /**
- * Get the description of the error.
+ * Get the description of the error code.
  *
- * @param errnum the error number
- * @param err optional error value
+ * In case of an unknown error this returns `"unknown error code"`.
  *
- * The success of this call are written into `err` if it is not `NULL`.
- * In case of an error this returns `"Unknown error number"`.
+ * @param errnum the error code
  *
  * @return The description of the error.
- *
- * @error `FIMO_EOK`: Operation was successful.
- * @error `FIMO_EINVAL`: The value of `errnum` is not a valid error number.
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-const char *fimo_strerrordesc(FimoError errnum, FimoError *err);
+const char *fimo_error_code_description(FimoErrorCode errnum);
 
 /**
  * Constructs an error code from an errno error code.
  *
- * @param errnum: errno error code
+ * Unknown errno codes translate to an invalid error code.
  *
- * Unknown errno codes translate to `FIMO_EUNKNOWN`.
+ * @param errnum: errno error code
  *
  * @return Status code.
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_error_from_errno(int errnum);
+FimoErrorCode fimo_error_code_from_errno(int errnum);
+
+/**
+ * Releases a `FimoResultString`.
+ *
+ * @param str string to release
+ */
+static FIMO_INLINE_ALWAYS void fimo_result_string_release(FimoResultString str) {
+    if (str.release) {
+        str.release(str.str);
+    }
+}
+
+#ifdef __cplusplus
+#define FIMO_IMPL_RESULT_INITIALIZER
+#define FIMO_IMPL_RESULT_STRING_INITIALIZER
+#else
+#define FIMO_IMPL_RESULT_INITIALIZER (FimoResult)
+#define FIMO_IMPL_RESULT_STRING_INITIALIZER (FimoResultString)
+#endif
+
+/**
+ * Constructs a `FimoResult` from a static string.
+ *
+ * @param error error string
+ *
+ * @return Result instance.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_static_string(const char *error) {
+    if (!error) {
+        return FIMO_IMPL_RESULT_INVALID_ERROR;
+    }
+    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)error, .vtable = &FIMO_IMPL_RESULT_STATIC_STRING_VTABLE};
+}
+
+/**
+ * Constructs a `FimoResult` from a dynamic string.
+ *
+ * The string must be allocated in a way that it can be freed with `fimo_free`.
+ *
+ * @param error error string
+ *
+ * @return Result instance.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_dynamic_string(const char *error) {
+    if (!error) {
+        return FIMO_IMPL_RESULT_INVALID_ERROR;
+    }
+    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)error, .vtable = &FIMO_IMPL_RESULT_DYNAMIC_STRING_VTABLE};
+}
+
+/**
+ * Constructs a `FimoResult` from a `FimoErrorCode`.
+ *
+ * @param code error code
+ *
+ * @return Result instance.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_error_code(FimoErrorCode code) {
+    if (code == FIMO_ERROR_CODE_OK) {
+        return FIMO_IMPL_RESULT_OK;
+    }
+    if (code > FIMO_ERROR_CODE_MAX) {
+        return FIMO_IMPL_RESULT_INVALID_ERROR;
+    }
+    FIMO_PRAGMA_MSVC(warning(push))
+    FIMO_PRAGMA_MSVC(warning(disable : 4306))
+    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)code, .vtable = &FIMO_IMPL_RESULT_ERROR_CODE_VTABLE};
+    FIMO_PRAGMA_MSVC(warning(pop))
+}
+
+/**
+ * Constructs a `FimoResult` from a `FimoSystemErrorCode`.
+ *
+ * @param code error code
+ *
+ * @return Result instace.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS FimoResult fimo_result_from_system_error_code(FimoSystemErrorCode code) {
+    FIMO_PRAGMA_MSVC(warning(push))
+    FIMO_PRAGMA_MSVC(warning(disable : 4312))
+    return FIMO_IMPL_RESULT_INITIALIZER{.data = (void *)code, .vtable = &FIMO_IMPL_RESULT_SYSTEM_ERROR_CODE_VTABLE};
+    FIMO_PRAGMA_MSVC(warning(pop))
+}
+
+/**
+ * Checks whether the `FimoResult` signifies an error.
+ *
+ * @param result result
+ *
+ * @return Whether the result is an error.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS bool fimo_result_is_error(FimoResult result) { return result.vtable != NULL; }
+
+/**
+ * Checks whether the `FimoResult` does not signify an error.
+ *
+ * @param result result
+ *
+ * @return Whether the result is not an error.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS bool fimo_result_is_ok(FimoResult result) { return result.vtable == NULL; }
+
+/**
+ * Releases the `FimoResult`.
+ *
+ * The value may not be used again after releasing it.
+ *
+ * @param result result to release
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS void fimo_result_release(FimoResult result) {
+    if (fimo_result_is_error(result) && result.vtable->v0.release) {
+        result.vtable->v0.release(result.data);
+    }
+}
+
+/**
+ * Get the error name contained in the `FimoResult`.
+ *
+ * In case `result` does not contain an error this returns `"FIMO_IMPL_RESULT_OK_NAME"`.
+ *
+ * @param result the result
+ *
+ * @return Error name.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS FimoResultString fimo_result_error_name(FimoResult result) {
+    if (fimo_result_is_ok(result)) {
+        return FIMO_IMPL_RESULT_OK_NAME;
+    }
+    return result.vtable->v0.error_name(result.data);
+}
+
+/**
+ * Get the error description contained in the `FimoResult`.
+ *
+ * In case `result` does not contain an error this returns `FIMO_IMPL_RESULT_OK_DESCRIPTION`.
+ *
+ * @param result the result
+ *
+ * @return Error description.
+ */
+FIMO_MUST_USE
+static FIMO_INLINE_ALWAYS FimoResultString fimo_result_error_description(FimoResult result) {
+    if (fimo_result_is_ok(result)) {
+        return FIMO_IMPL_RESULT_OK_DESCRIPTION;
+    }
+    return result.vtable->v0.error_description(result.data);
+}
+
+#undef FIMO_IMPL_RESULT_INITIALIZER
+#undef FIMO_IMPL_RESULT_STRING_INITIALIZER
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/graph.h
+++ b/ffi_library/fimo_std/include/fimo_std/graph.h
@@ -61,8 +61,8 @@ typedef struct FimoGraphNeighborsEdges FimoGraphNeighborsEdges;
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_new(size_t node_size, size_t edge_size, void (*node_free)(void *), void (*edge_free)(void *),
-                         FimoGraph **graph);
+FimoResult fimo_graph_new(size_t node_size, size_t edge_size, void (*node_free)(void *), void (*edge_free)(void *),
+                          FimoGraph **graph);
 
 /**
  * Destroys the graph.
@@ -111,7 +111,7 @@ size_t fimo_graph_edge_count(const FimoGraph *graph);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_neighbors_count(const FimoGraph *graph, FimoU64 node, bool inward, size_t *count);
+FimoResult fimo_graph_neighbors_count(const FimoGraph *graph, FimoU64 node, bool inward, size_t *count);
 
 /**
  * Adds a new node to the graph.
@@ -128,7 +128,7 @@ FimoError fimo_graph_neighbors_count(const FimoGraph *graph, FimoU64 node, bool 
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_add_node(FimoGraph *graph, const void *node_data, FimoU64 *node);
+FimoResult fimo_graph_add_node(FimoGraph *graph, const void *node_data, FimoU64 *node);
 
 /**
  * Access the data associated with a node.
@@ -143,7 +143,7 @@ FimoError fimo_graph_add_node(FimoGraph *graph, const void *node_data, FimoU64 *
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_node_data(const FimoGraph *graph, FimoU64 node, const void **node_data);
+FimoResult fimo_graph_node_data(const FimoGraph *graph, FimoU64 node, const void **node_data);
 
 /**
  * Adds an edge from `src_node` to `dst_node`.
@@ -164,8 +164,8 @@ FimoError fimo_graph_node_data(const FimoGraph *graph, FimoU64 node, const void 
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_add_edge(FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, const void *edge_data,
-                              void **old_edge_data, FimoU64 *edge);
+FimoResult fimo_graph_add_edge(FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, const void *edge_data,
+                               void **old_edge_data, FimoU64 *edge);
 
 /**
  * Updates the edge from `src_node` to `dst_node`.
@@ -186,8 +186,8 @@ FimoError fimo_graph_add_edge(FimoGraph *graph, FimoU64 src_node, FimoU64 dst_no
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_update_edge(FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, const void *edge_data,
-                                 void **old_edge_data, FimoU64 *edge);
+FimoResult fimo_graph_update_edge(FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, const void *edge_data,
+                                  void **old_edge_data, FimoU64 *edge);
 
 /**
  * Access the data associated with an edge.
@@ -202,7 +202,7 @@ FimoError fimo_graph_update_edge(FimoGraph *graph, FimoU64 src_node, FimoU64 dst
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_edge_data(const FimoGraph *graph, FimoU64 edge, const void **edge_data);
+FimoResult fimo_graph_edge_data(const FimoGraph *graph, FimoU64 edge, const void **edge_data);
 
 /**
  * Returns the node endpoints of an edge.
@@ -218,7 +218,7 @@ FimoError fimo_graph_edge_data(const FimoGraph *graph, FimoU64 edge, const void 
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_edge_endpoints(const FimoGraph *graph, FimoU64 edge, FimoU64 *start_node, FimoU64 *end_node);
+FimoResult fimo_graph_edge_endpoints(const FimoGraph *graph, FimoU64 edge, FimoU64 *start_node, FimoU64 *end_node);
 
 /**
  * Removes a node and all its edges from the graph.
@@ -233,7 +233,7 @@ FimoError fimo_graph_edge_endpoints(const FimoGraph *graph, FimoU64 edge, FimoU6
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_remove_node(FimoGraph *graph, FimoU64 node, void **node_data);
+FimoResult fimo_graph_remove_node(FimoGraph *graph, FimoU64 node, void **node_data);
 
 /**
  * Removes an edge from the graph.
@@ -248,7 +248,7 @@ FimoError fimo_graph_remove_node(FimoGraph *graph, FimoU64 node, void **node_dat
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_remove_edge(FimoGraph *graph, FimoU64 edge, void **edge_data);
+FimoResult fimo_graph_remove_edge(FimoGraph *graph, FimoU64 edge, void **edge_data);
 
 /**
  * Checks whether an edge exists from `src_node` to `dst_node`.
@@ -264,7 +264,7 @@ FimoError fimo_graph_remove_edge(FimoGraph *graph, FimoU64 edge, void **edge_dat
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_contains_edge(const FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, bool *contained);
+FimoResult fimo_graph_contains_edge(const FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, bool *contained);
 
 /**
  * Finds the edge index from `src_node` to `dst_node`.
@@ -282,8 +282,8 @@ FimoError fimo_graph_contains_edge(const FimoGraph *graph, FimoU64 src_node, Fim
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_find_edge(const FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, FimoU64 *edge,
-                               bool *contained);
+FimoResult fimo_graph_find_edge(const FimoGraph *graph, FimoU64 src_node, FimoU64 dst_node, FimoU64 *edge,
+                                bool *contained);
 
 /**
  * Constructs a new iterator over the nodes of a graph.
@@ -299,7 +299,7 @@ FimoError fimo_graph_find_edge(const FimoGraph *graph, FimoU64 src_node, FimoU64
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_nodes_new(const FimoGraph *graph, FimoGraphNodes **iter, bool *has_value);
+FimoResult fimo_graph_nodes_new(const FimoGraph *graph, FimoGraphNodes **iter, bool *has_value);
 
 /**
  * Performs an iteration step to the next node.
@@ -315,7 +315,7 @@ FimoError fimo_graph_nodes_new(const FimoGraph *graph, FimoGraphNodes **iter, bo
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_nodes_next(FimoGraphNodes *iter, bool *has_value);
+FimoResult fimo_graph_nodes_next(FimoGraphNodes *iter, bool *has_value);
 
 /**
  * Queries the node index and data at the current iterator position.
@@ -332,7 +332,7 @@ FimoError fimo_graph_nodes_next(FimoGraphNodes *iter, bool *has_value);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_nodes_item(const FimoGraphNodes *iter, FimoU64 *node, const void **node_data);
+FimoResult fimo_graph_nodes_item(const FimoGraphNodes *iter, FimoU64 *node, const void **node_data);
 
 /**
  * Frees up a nodes iterator.
@@ -356,7 +356,7 @@ void fimo_graph_nodes_free(FimoGraphNodes *iter);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_edges_new(const FimoGraph *graph, FimoGraphEdges **iter, bool *has_value);
+FimoResult fimo_graph_edges_new(const FimoGraph *graph, FimoGraphEdges **iter, bool *has_value);
 
 /**
  * Performs an iteration step to the next edge.
@@ -372,7 +372,7 @@ FimoError fimo_graph_edges_new(const FimoGraph *graph, FimoGraphEdges **iter, bo
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_edges_next(FimoGraphEdges *iter, bool *has_value);
+FimoResult fimo_graph_edges_next(FimoGraphEdges *iter, bool *has_value);
 
 /**
  * Queries the edge index and data at the current iterator position.
@@ -389,7 +389,7 @@ FimoError fimo_graph_edges_next(FimoGraphEdges *iter, bool *has_value);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_edges_item(const FimoGraphEdges *iter, FimoU64 *edge, const void **edge_data);
+FimoResult fimo_graph_edges_item(const FimoGraphEdges *iter, FimoU64 *edge, const void **edge_data);
 
 /**
  * Frees up an edges iterator.
@@ -418,7 +418,7 @@ void fimo_graph_edges_free(FimoGraphEdges *iter);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_externals_new(const FimoGraph *graph, bool sink, FimoGraphExternals **iter, bool *has_value);
+FimoResult fimo_graph_externals_new(const FimoGraph *graph, bool sink, FimoGraphExternals **iter, bool *has_value);
 
 /**
  * Performs an iteration step to the next external node.
@@ -434,7 +434,7 @@ FimoError fimo_graph_externals_new(const FimoGraph *graph, bool sink, FimoGraphE
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_externals_next(FimoGraphExternals *iter, bool *has_value);
+FimoResult fimo_graph_externals_next(FimoGraphExternals *iter, bool *has_value);
 
 /**
  * Queries the node index and data at the current iterator position.
@@ -451,7 +451,7 @@ FimoError fimo_graph_externals_next(FimoGraphExternals *iter, bool *has_value);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_externals_item(const FimoGraphExternals *iter, FimoU64 *node, const void **node_data);
+FimoResult fimo_graph_externals_item(const FimoGraphExternals *iter, FimoU64 *node, const void **node_data);
 
 /**
  * Frees up a externals iterator.
@@ -481,8 +481,8 @@ void fimo_graph_externals_free(FimoGraphExternals *iter);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_neighbors_new(const FimoGraph *graph, FimoU64 node, bool inward, FimoGraphNeighbors **iter,
-                                   bool *has_value);
+FimoResult fimo_graph_neighbors_new(const FimoGraph *graph, FimoU64 node, bool inward, FimoGraphNeighbors **iter,
+                                    bool *has_value);
 
 /**
  * Performs an iteration step.
@@ -498,7 +498,7 @@ FimoError fimo_graph_neighbors_new(const FimoGraph *graph, FimoU64 node, bool in
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_neighbors_next(FimoGraphNeighbors *iter, bool *has_value);
+FimoResult fimo_graph_neighbors_next(FimoGraphNeighbors *iter, bool *has_value);
 
 /**
  * Queries the node index at the current iterator position.
@@ -513,7 +513,7 @@ FimoError fimo_graph_neighbors_next(FimoGraphNeighbors *iter, bool *has_value);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_neighbors_item(const FimoGraphNeighbors *iter, FimoU64 *node);
+FimoResult fimo_graph_neighbors_item(const FimoGraphNeighbors *iter, FimoU64 *node);
 
 /**
  * Frees up a neighbors iterator.
@@ -544,8 +544,8 @@ void fimo_graph_neighbors_free(FimoGraphNeighbors *iter);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_neighbors_edges_new(const FimoGraph *graph, FimoU64 node, bool inward,
-                                         FimoGraphNeighborsEdges **iter, bool *has_value);
+FimoResult fimo_graph_neighbors_edges_new(const FimoGraph *graph, FimoU64 node, bool inward,
+                                          FimoGraphNeighborsEdges **iter, bool *has_value);
 
 /**
  * Performs an iteration step.
@@ -561,7 +561,7 @@ FimoError fimo_graph_neighbors_edges_new(const FimoGraph *graph, FimoU64 node, b
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_neighbors_edges_next(FimoGraphNeighborsEdges *iter, bool *has_value);
+FimoResult fimo_graph_neighbors_edges_next(FimoGraphNeighborsEdges *iter, bool *has_value);
 
 /**
  * Queries the edge index at the current iterator position.
@@ -576,7 +576,7 @@ FimoError fimo_graph_neighbors_edges_next(FimoGraphNeighborsEdges *iter, bool *h
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_neighbors_edges_item(const FimoGraphNeighborsEdges *iter, FimoU64 *edge);
+FimoResult fimo_graph_neighbors_edges_item(const FimoGraphNeighborsEdges *iter, FimoU64 *edge);
 
 /**
  * Frees up a edges iterator.
@@ -595,7 +595,7 @@ void fimo_graph_neighbors_edges_free(FimoGraphNeighborsEdges *iter);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_clear(FimoGraph *graph);
+FimoResult fimo_graph_clear(FimoGraph *graph);
 
 /**
  * Removes all edges from the graph.
@@ -606,7 +606,7 @@ FimoError fimo_graph_clear(FimoGraph *graph);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_clear_edges(FimoGraph *graph);
+FimoResult fimo_graph_clear_edges(FimoGraph *graph);
 
 /**
  * Inverts the direction of all edges in the graph.
@@ -617,7 +617,7 @@ FimoError fimo_graph_clear_edges(FimoGraph *graph);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_reverse(FimoGraph *graph);
+FimoResult fimo_graph_reverse(FimoGraph *graph);
 
 /**
  * Initializes a new graph by cloning another one.
@@ -638,9 +638,9 @@ FimoError fimo_graph_reverse(FimoGraph *graph);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_clone(const FimoGraph *graph, FimoGraph **new_graph,
-                           FimoError (*node_mapper)(FimoU64, FimoU64, void *),
-                           FimoError (*edge_mapper)(FimoU64, FimoU64, void *), void *user_data);
+FimoResult fimo_graph_clone(const FimoGraph *graph, FimoGraph **new_graph,
+                            FimoResult (*node_mapper)(FimoU64, FimoU64, void *),
+                            FimoResult (*edge_mapper)(FimoU64, FimoU64, void *), void *user_data);
 
 /**
  * Initializes a new subgraph containing all reachable nodes.
@@ -665,9 +665,9 @@ FimoError fimo_graph_clone(const FimoGraph *graph, FimoGraph **new_graph,
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_clone_reachable_subgraph(const FimoGraph *graph, FimoGraph **sub_graph, FimoU64 start_node,
-                                              FimoError (*node_mapper)(FimoU64, FimoU64, void *),
-                                              FimoError (*edge_mapper)(FimoU64, FimoU64, void *), void *user_data);
+FimoResult fimo_graph_clone_reachable_subgraph(const FimoGraph *graph, FimoGraph **sub_graph, FimoU64 start_node,
+                                               FimoResult (*node_mapper)(FimoU64, FimoU64, void *),
+                                               FimoResult (*edge_mapper)(FimoU64, FimoU64, void *), void *user_data);
 
 /**
  * Checks whether there is a path from `start_node` to `end_node`.
@@ -684,7 +684,7 @@ FimoError fimo_graph_clone_reachable_subgraph(const FimoGraph *graph, FimoGraph 
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_path_exists(const FimoGraph *graph, FimoU64 start_node, FimoU64 end_node, bool *path_exists);
+FimoResult fimo_graph_path_exists(const FimoGraph *graph, FimoU64 start_node, FimoU64 end_node, bool *path_exists);
 
 /**
  * Checks whether the graph contains any cycles.
@@ -696,7 +696,7 @@ FimoError fimo_graph_path_exists(const FimoGraph *graph, FimoU64 start_node, Fim
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_is_cyclic(const FimoGraph *graph, bool *is_cyclic);
+FimoResult fimo_graph_is_cyclic(const FimoGraph *graph, bool *is_cyclic);
 
 /**
  * Computes a topological sorting of the graph.
@@ -709,7 +709,7 @@ FimoError fimo_graph_is_cyclic(const FimoGraph *graph, bool *is_cyclic);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_graph_topological_sort(const FimoGraph *graph, bool inward, FimoArrayList *nodes);
+FimoResult fimo_graph_topological_sort(const FimoGraph *graph, bool inward, FimoArrayList *nodes);
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/impl/tracing.h
+++ b/ffi_library/fimo_std/include/fimo_std/impl/tracing.h
@@ -36,7 +36,7 @@ typedef struct FimoImplTracingFmtArgs {
  *
  * @return Status code.
  */
-FimoError fimo_impl_tracing_fmt(char *buffer, FimoUSize buffer_size, const void *args, FimoUSize *written_size);
+FimoResult fimo_impl_tracing_fmt(char *buffer, FimoUSize buffer_size, const void *args, FimoUSize *written_size);
 
 typedef struct FimoTracingSpanDesc FimoTracingSpanDesc;
 typedef struct FimoTracingEvent FimoTracingEvent;
@@ -45,16 +45,16 @@ typedef struct FimoTracingEvent FimoTracingEvent;
 //// Default Subscriber
 ///////////////////////////////////////////////////////////////////////
 
-FimoError fimo_impl_tracing_default_subscriber_call_stack_create(void *subscriber, const FimoTime *time, void **stack);
+FimoResult fimo_impl_tracing_default_subscriber_call_stack_create(void *subscriber, const FimoTime *time, void **stack);
 void fimo_impl_tracing_default_subscriber_call_stack_drop(void *subscriber, void *stack);
 void fimo_impl_tracing_default_subscriber_call_stack_destroy(void *subscriber, const FimoTime *time, void *stack);
 void fimo_impl_tracing_default_subscriber_call_stack_unblock(void *subscriber, const FimoTime *time, void *stack);
 void fimo_impl_tracing_default_subscriber_call_stack_suspend(void *subscriber, const FimoTime *time, void *stack,
                                                              bool block);
 void fimo_impl_tracing_default_subscriber_call_stack_resume(void *subscriber, const FimoTime *time, void *stack);
-FimoError fimo_impl_tracing_default_subscriber_span_push(void *subscriber, const FimoTime *time,
-                                                         const FimoTracingSpanDesc *span_desc, const char *message,
-                                                         FimoUSize message_len, void *stack);
+FimoResult fimo_impl_tracing_default_subscriber_span_push(void *subscriber, const FimoTime *time,
+                                                          const FimoTracingSpanDesc *span_desc, const char *message,
+                                                          FimoUSize message_len, void *stack);
 void fimo_impl_tracing_default_subscriber_span_drop(void *subscriber, void *stack);
 void fimo_impl_tracing_default_subscriber_span_pop(void *subscriber, const FimoTime *time, void *stack);
 void fimo_impl_tracing_default_subscriber_event_emit(void *subscriber, const FimoTime *time, void *stack,

--- a/ffi_library/fimo_std/include/fimo_std/internal/context.h
+++ b/ffi_library/fimo_std/include/fimo_std/internal/context.h
@@ -40,7 +40,7 @@ typedef struct FimoInternalContext {
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_context_init(const FimoBaseStructIn **options, FimoContext *context);
+FimoResult fimo_internal_context_init(const FimoBaseStructIn **options, FimoContext *context);
 
 /**
  * Returns the public context for the internal context.
@@ -53,7 +53,7 @@ FimoError fimo_internal_context_init(const FimoBaseStructIn **options, FimoConte
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_context_to_public_ctx(void *ptr, FimoContext *context);
+FimoResult fimo_internal_context_to_public_ctx(void *ptr, FimoContext *context);
 
 /**
  * Acquires a reference to the context by increasing the reference count.
@@ -78,7 +78,7 @@ void fimo_internal_context_release(void *ptr);
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_context_check_version(void *ptr, const FimoVersion *required);
+FimoResult fimo_internal_context_check_version(void *ptr, const FimoVersion *required);
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/internal/module.h
+++ b/ffi_library/fimo_std/include/fimo_std/internal/module.h
@@ -30,67 +30,68 @@ typedef struct FimoInternalModuleContext {
 //// Trampoline functions
 ///////////////////////////////////////////////////////////////////////
 
-FimoError fimo_internal_trampoline_module_pseudo_module_new(void *ctx, const FimoModule **module);
-FimoError fimo_internal_trampoline_module_pseudo_module_destroy(void *ctx, const FimoModule *module,
-                                                                FimoContext *module_context);
-FimoError fimo_internal_trampoline_module_set_new(void *ctx, FimoModuleLoadingSet **set);
-FimoError fimo_internal_trampoline_module_set_has_module(void *ctx, FimoModuleLoadingSet *set, const char *name,
-                                                         bool *has_module);
-FimoError fimo_internal_trampoline_module_set_has_symbol(void *ctx, FimoModuleLoadingSet *set, const char *name,
-                                                         const char *ns, FimoVersion version, bool *has_symbol);
-FimoError fimo_internal_trampoline_module_set_append_callback(void *ctx, FimoModuleLoadingSet *set,
-                                                              const char *module_name,
-                                                              FimoModuleLoadingSuccessCallback on_success,
-                                                              FimoModuleLoadingErrorCallback on_error, void *user_data);
-FimoError fimo_internal_trampoline_module_set_append_freestanding_module(void *ctx, const FimoModule *module,
-                                                                         FimoModuleLoadingSet *set,
-                                                                         const FimoModuleExport *export);
-FimoError fimo_internal_trampoline_module_set_append_modules(
+FimoResult fimo_internal_trampoline_module_pseudo_module_new(void *ctx, const FimoModule **module);
+FimoResult fimo_internal_trampoline_module_pseudo_module_destroy(void *ctx, const FimoModule *module,
+                                                                 FimoContext *module_context);
+FimoResult fimo_internal_trampoline_module_set_new(void *ctx, FimoModuleLoadingSet **set);
+FimoResult fimo_internal_trampoline_module_set_has_module(void *ctx, FimoModuleLoadingSet *set, const char *name,
+                                                          bool *has_module);
+FimoResult fimo_internal_trampoline_module_set_has_symbol(void *ctx, FimoModuleLoadingSet *set, const char *name,
+                                                          const char *ns, FimoVersion version, bool *has_symbol);
+FimoResult fimo_internal_trampoline_module_set_append_callback(void *ctx, FimoModuleLoadingSet *set,
+                                                               const char *module_name,
+                                                               FimoModuleLoadingSuccessCallback on_success,
+                                                               FimoModuleLoadingErrorCallback on_error,
+                                                               void *user_data);
+FimoResult fimo_internal_trampoline_module_set_append_freestanding_module(void *ctx, const FimoModule *module,
+                                                                          FimoModuleLoadingSet *set,
+                                                                          const FimoModuleExport *export);
+FimoResult fimo_internal_trampoline_module_set_append_modules(
         void *ctx, FimoModuleLoadingSet *set, const char *module_path, FimoModuleLoadingFilter filter,
         void *filter_data, void (*export_iterator)(bool (*)(const FimoModuleExport *, void *), void *),
         const void *binary_handle);
-FimoError fimo_internal_trampoline_module_set_dismiss(void *ctx, FimoModuleLoadingSet *set);
-FimoError fimo_internal_trampoline_module_set_finish(void *ctx, FimoModuleLoadingSet *set);
-FimoError fimo_internal_trampoline_module_find_by_name(void *ctx, const char *name, const FimoModuleInfo **module);
-FimoError fimo_internal_trampoline_module_find_by_symbol(void *ctx, const char *name, const char *ns,
-                                                         FimoVersion version, const FimoModuleInfo **module);
-FimoError fimo_internal_trampoline_module_namespace_exists(void *ctx, const char *ns, bool *exists);
-FimoError fimo_internal_trampoline_module_namespace_include(void *ctx, const FimoModule *module, const char *ns);
-FimoError fimo_internal_trampoline_module_namespace_exclude(void *ctx, const FimoModule *module, const char *ns);
-FimoError fimo_internal_trampoline_module_namespace_included(void *ctx, const FimoModule *module, const char *ns,
-                                                             bool *is_included, bool *is_static);
-FimoError fimo_internal_trampoline_module_acquire_dependency(void *ctx, const FimoModule *module,
-                                                             const FimoModuleInfo *dependency);
-FimoError fimo_internal_trampoline_module_relinquish_dependency(void *ctx, const FimoModule *module,
-                                                                const FimoModuleInfo *dependency);
-FimoError fimo_internal_trampoline_module_has_dependency(void *ctx, const FimoModule *module,
-                                                         const FimoModuleInfo *other, bool *has_dependency,
-                                                         bool *is_static);
-FimoError fimo_internal_trampoline_module_param_query(void *ctx, const char *module_name, const char *param,
-                                                      FimoModuleParamType *type, FimoModuleParamAccess *read,
-                                                      FimoModuleParamAccess *write);
-FimoError fimo_internal_trampoline_module_param_set_public(void *ctx, const void *value, FimoModuleParamType type,
-                                                           const char *module_name, const char *param);
-FimoError fimo_internal_trampoline_module_param_get_public(void *ctx, void *value, FimoModuleParamType *type,
-                                                           const char *module_name, const char *param);
-FimoError fimo_internal_trampoline_module_param_set_dependency(void *ctx, const FimoModule *module, const void *value,
-                                                               FimoModuleParamType type, const char *module_name,
-                                                               const char *param);
-FimoError fimo_internal_trampoline_module_param_get_dependency(void *ctx, const FimoModule *module, void *value,
-                                                               FimoModuleParamType *type, const char *module_name,
-                                                               const char *param);
-FimoError fimo_internal_trampoline_module_load_symbol(void *ctx, const FimoModule *module, const char *name,
-                                                      const char *ns, FimoVersion version,
-                                                      const FimoModuleRawSymbol **symbol);
-FimoError fimo_internal_trampoline_module_unload(void *ctx, const FimoModuleInfo *module);
-FimoError fimo_internal_trampoline_module_param_set_private(void *ctx, const FimoModule *module, const void *value,
-                                                            FimoModuleParamType type, FimoModuleParam *param);
-FimoError fimo_internal_trampoline_module_param_get_private(void *ctx, const FimoModule *module, void *value,
-                                                            FimoModuleParamType *type, const FimoModuleParam *param);
-FimoError fimo_internal_trampoline_module_param_set_inner(void *ctx, const FimoModule *module, const void *value,
-                                                          FimoModuleParamType type, FimoModuleParamData *param);
-FimoError fimo_internal_trampoline_module_get_inner(void *ctx, const FimoModule *module, void *value,
-                                                    FimoModuleParamType *type, const FimoModuleParamData *param);
+FimoResult fimo_internal_trampoline_module_set_dismiss(void *ctx, FimoModuleLoadingSet *set);
+FimoResult fimo_internal_trampoline_module_set_finish(void *ctx, FimoModuleLoadingSet *set);
+FimoResult fimo_internal_trampoline_module_find_by_name(void *ctx, const char *name, const FimoModuleInfo **module);
+FimoResult fimo_internal_trampoline_module_find_by_symbol(void *ctx, const char *name, const char *ns,
+                                                          FimoVersion version, const FimoModuleInfo **module);
+FimoResult fimo_internal_trampoline_module_namespace_exists(void *ctx, const char *ns, bool *exists);
+FimoResult fimo_internal_trampoline_module_namespace_include(void *ctx, const FimoModule *module, const char *ns);
+FimoResult fimo_internal_trampoline_module_namespace_exclude(void *ctx, const FimoModule *module, const char *ns);
+FimoResult fimo_internal_trampoline_module_namespace_included(void *ctx, const FimoModule *module, const char *ns,
+                                                              bool *is_included, bool *is_static);
+FimoResult fimo_internal_trampoline_module_acquire_dependency(void *ctx, const FimoModule *module,
+                                                              const FimoModuleInfo *dependency);
+FimoResult fimo_internal_trampoline_module_relinquish_dependency(void *ctx, const FimoModule *module,
+                                                                 const FimoModuleInfo *dependency);
+FimoResult fimo_internal_trampoline_module_has_dependency(void *ctx, const FimoModule *module,
+                                                          const FimoModuleInfo *other, bool *has_dependency,
+                                                          bool *is_static);
+FimoResult fimo_internal_trampoline_module_param_query(void *ctx, const char *module_name, const char *param,
+                                                       FimoModuleParamType *type, FimoModuleParamAccess *read,
+                                                       FimoModuleParamAccess *write);
+FimoResult fimo_internal_trampoline_module_param_set_public(void *ctx, const void *value, FimoModuleParamType type,
+                                                            const char *module_name, const char *param);
+FimoResult fimo_internal_trampoline_module_param_get_public(void *ctx, void *value, FimoModuleParamType *type,
+                                                            const char *module_name, const char *param);
+FimoResult fimo_internal_trampoline_module_param_set_dependency(void *ctx, const FimoModule *module, const void *value,
+                                                                FimoModuleParamType type, const char *module_name,
+                                                                const char *param);
+FimoResult fimo_internal_trampoline_module_param_get_dependency(void *ctx, const FimoModule *module, void *value,
+                                                                FimoModuleParamType *type, const char *module_name,
+                                                                const char *param);
+FimoResult fimo_internal_trampoline_module_load_symbol(void *ctx, const FimoModule *module, const char *name,
+                                                       const char *ns, FimoVersion version,
+                                                       const FimoModuleRawSymbol **symbol);
+FimoResult fimo_internal_trampoline_module_unload(void *ctx, const FimoModuleInfo *module);
+FimoResult fimo_internal_trampoline_module_param_set_private(void *ctx, const FimoModule *module, const void *value,
+                                                             FimoModuleParamType type, FimoModuleParam *param);
+FimoResult fimo_internal_trampoline_module_param_get_private(void *ctx, const FimoModule *module, void *value,
+                                                             FimoModuleParamType *type, const FimoModuleParam *param);
+FimoResult fimo_internal_trampoline_module_param_set_inner(void *ctx, const FimoModule *module, const void *value,
+                                                           FimoModuleParamType type, FimoModuleParamData *param);
+FimoResult fimo_internal_trampoline_module_get_inner(void *ctx, const FimoModule *module, void *value,
+                                                     FimoModuleParamType *type, const FimoModuleParamData *param);
 
 ///////////////////////////////////////////////////////////////////////
 //// Module Subsystem API
@@ -104,7 +105,7 @@ FimoError fimo_internal_trampoline_module_get_inner(void *ctx, const FimoModule 
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_init(FimoInternalModuleContext *ctx);
+FimoResult fimo_internal_module_init(FimoInternalModuleContext *ctx);
 
 /**
  * Destroys the module subsystem.
@@ -128,7 +129,7 @@ void fimo_internal_module_destroy(FimoInternalModuleContext *ctx);
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_pseudo_module_new(FimoInternalModuleContext *ctx, const FimoModule **module);
+FimoResult fimo_internal_module_pseudo_module_new(FimoInternalModuleContext *ctx, const FimoModule **module);
 
 /**
  * Destroys an existing pseudo module.
@@ -143,8 +144,8 @@ FimoError fimo_internal_module_pseudo_module_new(FimoInternalModuleContext *ctx,
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_pseudo_module_destroy(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                     FimoContext *module_context);
+FimoResult fimo_internal_module_pseudo_module_destroy(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                      FimoContext *module_context);
 
 /**
  * Constructs a new empty module set.
@@ -161,7 +162,7 @@ FimoError fimo_internal_module_pseudo_module_destroy(FimoInternalModuleContext *
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_set_new(FimoInternalModuleContext *ctx, FimoModuleLoadingSet **set);
+FimoResult fimo_internal_module_set_new(FimoInternalModuleContext *ctx, FimoModuleLoadingSet **set);
 
 /**
  * Checks whether a module set contains a module.
@@ -174,8 +175,8 @@ FimoError fimo_internal_module_set_new(FimoInternalModuleContext *ctx, FimoModul
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_set_has_module(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set,
-                                              const char *name, bool *has_module);
+FimoResult fimo_internal_module_set_has_module(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set,
+                                               const char *name, bool *has_module);
 
 /**
  * Checks whether a module set contains a symbol.
@@ -190,8 +191,8 @@ FimoError fimo_internal_module_set_has_module(FimoInternalModuleContext *ctx, Fi
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_set_has_symbol(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set,
-                                              const char *name, const char *ns, FimoVersion version, bool *has_symbol);
+FimoResult fimo_internal_module_set_has_symbol(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set,
+                                               const char *name, const char *ns, FimoVersion version, bool *has_symbol);
 
 /**
  * Adds a status callback to the module set.
@@ -215,9 +216,10 @@ FimoError fimo_internal_module_set_has_symbol(FimoInternalModuleContext *ctx, Fi
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_set_append_callback(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set,
-                                                   const char *module_name, FimoModuleLoadingSuccessCallback on_success,
-                                                   FimoModuleLoadingErrorCallback on_error, void *user_data);
+FimoResult fimo_internal_module_set_append_callback(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set,
+                                                    const char *module_name,
+                                                    FimoModuleLoadingSuccessCallback on_success,
+                                                    FimoModuleLoadingErrorCallback on_error, void *user_data);
 
 /**
  * Adds a freestanding module to the module set.
@@ -244,9 +246,9 @@ FimoError fimo_internal_module_set_append_callback(FimoInternalModuleContext *ct
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_set_append_freestanding_module(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                              FimoModuleLoadingSet *set,
-                                                              const FimoModuleExport *export);
+FimoResult fimo_internal_module_set_append_freestanding_module(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                               FimoModuleLoadingSet *set,
+                                                               const FimoModuleExport *export);
 
 /**
  * Adds modules to the module set.
@@ -278,7 +280,7 @@ FimoError fimo_internal_module_set_append_freestanding_module(FimoInternalModule
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError
+FimoResult
 fimo_internal_module_set_append_modules(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set,
                                         const char *module_path, FimoModuleLoadingFilter filter, void *filter_data,
                                         void (*export_iterator)(bool (*)(const FimoModuleExport *, void *), void *),
@@ -296,7 +298,7 @@ fimo_internal_module_set_append_modules(FimoInternalModuleContext *ctx, FimoModu
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_set_dismiss(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set);
+FimoResult fimo_internal_module_set_dismiss(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set);
 
 /**
  * Destroys the module set and loads the modules contained in it.
@@ -313,7 +315,7 @@ FimoError fimo_internal_module_set_dismiss(FimoInternalModuleContext *ctx, FimoM
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_set_finish(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set);
+FimoResult fimo_internal_module_set_finish(FimoInternalModuleContext *ctx, FimoModuleLoadingSet *set);
 
 /**
  * Searches for a module by it's name.
@@ -327,8 +329,8 @@ FimoError fimo_internal_module_set_finish(FimoInternalModuleContext *ctx, FimoMo
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_find_by_name(FimoInternalModuleContext *ctx, const char *name,
-                                            const FimoModuleInfo **module);
+FimoResult fimo_internal_module_find_by_name(FimoInternalModuleContext *ctx, const char *name,
+                                             const FimoModuleInfo **module);
 
 /**
  * Searches for a module by a symbol it exports.
@@ -344,8 +346,8 @@ FimoError fimo_internal_module_find_by_name(FimoInternalModuleContext *ctx, cons
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_find_by_symbol(FimoInternalModuleContext *ctx, const char *name, const char *ns,
-                                              FimoVersion version, const FimoModuleInfo **module);
+FimoResult fimo_internal_module_find_by_symbol(FimoInternalModuleContext *ctx, const char *name, const char *ns,
+                                               FimoVersion version, const FimoModuleInfo **module);
 
 /**
  * Checks for the presence of a namespace in the module backend.
@@ -360,7 +362,7 @@ FimoError fimo_internal_module_find_by_symbol(FimoInternalModuleContext *ctx, co
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_namespace_exists(FimoInternalModuleContext *ctx, const char *ns, bool *exists);
+FimoResult fimo_internal_module_namespace_exists(FimoInternalModuleContext *ctx, const char *ns, bool *exists);
 
 /**
  * Includes a namespace by the module.
@@ -376,8 +378,8 @@ FimoError fimo_internal_module_namespace_exists(FimoInternalModuleContext *ctx, 
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_namespace_include(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                 const char *ns);
+FimoResult fimo_internal_module_namespace_include(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                  const char *ns);
 
 /**
  * Removes a namespace include from the module.
@@ -395,8 +397,8 @@ FimoError fimo_internal_module_namespace_include(FimoInternalModuleContext *ctx,
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_namespace_exclude(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                 const char *ns);
+FimoResult fimo_internal_module_namespace_exclude(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                  const char *ns);
 
 /**
  * Checks if a module includes a namespace.
@@ -418,8 +420,8 @@ FimoError fimo_internal_module_namespace_exclude(FimoInternalModuleContext *ctx,
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_namespace_included(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                  const char *ns, bool *is_included, bool *is_static);
+FimoResult fimo_internal_module_namespace_included(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                   const char *ns, bool *is_included, bool *is_static);
 
 /**
  * Acquires another module as a dependency.
@@ -438,8 +440,8 @@ FimoError fimo_internal_module_namespace_included(FimoInternalModuleContext *ctx
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_acquire_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                  const FimoModuleInfo *dependency);
+FimoResult fimo_internal_module_acquire_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                   const FimoModuleInfo *dependency);
 
 /**
  * Removes a module as a dependency.
@@ -459,8 +461,8 @@ FimoError fimo_internal_module_acquire_dependency(FimoInternalModuleContext *ctx
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_relinquish_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                     const FimoModuleInfo *dependency);
+FimoResult fimo_internal_module_relinquish_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                      const FimoModuleInfo *dependency);
 
 /**
  * Checks if a module depends on another module.
@@ -482,8 +484,8 @@ FimoError fimo_internal_module_relinquish_dependency(FimoInternalModuleContext *
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_has_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                              const FimoModuleInfo *other, bool *has_dependency, bool *is_static);
+FimoResult fimo_internal_module_has_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                               const FimoModuleInfo *other, bool *has_dependency, bool *is_static);
 
 /**
  * Loads a symbol from the module backend.
@@ -507,8 +509,8 @@ FimoError fimo_internal_module_has_dependency(FimoInternalModuleContext *ctx, co
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_load_symbol(FimoInternalModuleContext *ctx, const FimoModule *module, const char *name,
-                                           const char *ns, FimoVersion version, const FimoModuleRawSymbol **symbol);
+FimoResult fimo_internal_module_load_symbol(FimoInternalModuleContext *ctx, const FimoModule *module, const char *name,
+                                            const char *ns, FimoVersion version, const FimoModuleRawSymbol **symbol);
 
 /**
  * Unloads a module.
@@ -526,7 +528,7 @@ FimoError fimo_internal_module_load_symbol(FimoInternalModuleContext *ctx, const
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_unload(FimoInternalModuleContext *ctx, const FimoModuleInfo *module);
+FimoResult fimo_internal_module_unload(FimoInternalModuleContext *ctx, const FimoModuleInfo *module);
 
 /**
  * Queries the info of a module parameter.
@@ -545,9 +547,9 @@ FimoError fimo_internal_module_unload(FimoInternalModuleContext *ctx, const Fimo
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_query(FimoInternalModuleContext *ctx, const char *module_name, const char *param,
-                                           FimoModuleParamType *type, FimoModuleParamAccess *read,
-                                           FimoModuleParamAccess *write);
+FimoResult fimo_internal_module_param_query(FimoInternalModuleContext *ctx, const char *module_name, const char *param,
+                                            FimoModuleParamType *type, FimoModuleParamAccess *read,
+                                            FimoModuleParamAccess *write);
 
 /**
  * Sets a module parameter with public write access.
@@ -566,9 +568,9 @@ FimoError fimo_internal_module_param_query(FimoInternalModuleContext *ctx, const
  *
  * @return Status code.
  */
-FIMO_MUST_USE FimoError fimo_internal_module_param_set_public(FimoInternalModuleContext *ctx, const void *value,
-                                                              FimoModuleParamType type, const char *module_name,
-                                                              const char *param);
+FIMO_MUST_USE
+FimoResult fimo_internal_module_param_set_public(FimoInternalModuleContext *ctx, const void *value,
+                                                 FimoModuleParamType type, const char *module_name, const char *param);
 
 /**
  * Reads a module parameter with public read access.
@@ -588,8 +590,8 @@ FIMO_MUST_USE FimoError fimo_internal_module_param_set_public(FimoInternalModule
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_get_public(FimoInternalModuleContext *ctx, void *value, FimoModuleParamType *type,
-                                                const char *module_name, const char *param);
+FimoResult fimo_internal_module_param_get_public(FimoInternalModuleContext *ctx, void *value, FimoModuleParamType *type,
+                                                 const char *module_name, const char *param);
 
 /**
  * Sets a module parameter with dependency write access.
@@ -610,9 +612,9 @@ FimoError fimo_internal_module_param_get_public(FimoInternalModuleContext *ctx, 
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_set_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                    const void *value, FimoModuleParamType type,
-                                                    const char *module_name, const char *param);
+FimoResult fimo_internal_module_param_set_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                     const void *value, FimoModuleParamType type,
+                                                     const char *module_name, const char *param);
 
 /**
  * Reads a module parameter with dependency read access.
@@ -633,9 +635,9 @@ FimoError fimo_internal_module_param_set_dependency(FimoInternalModuleContext *c
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_get_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                    void *value, FimoModuleParamType *type, const char *module_name,
-                                                    const char *param);
+FimoResult fimo_internal_module_param_get_dependency(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                     void *value, FimoModuleParamType *type, const char *module_name,
+                                                     const char *param);
 
 /**
  * Setter for a module parameter.
@@ -651,8 +653,8 @@ FimoError fimo_internal_module_param_get_dependency(FimoInternalModuleContext *c
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_set_private(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                                 const void *value, FimoModuleParamType type, FimoModuleParam *param);
+FimoResult fimo_internal_module_param_set_private(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                  const void *value, FimoModuleParamType type, FimoModuleParam *param);
 
 /**
  * Getter for a module parameter.
@@ -666,8 +668,8 @@ FimoError fimo_internal_module_param_set_private(FimoInternalModuleContext *ctx,
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_get_private(FimoInternalModuleContext *ctx, const FimoModule *module, void *value,
-                                                 FimoModuleParamType *type, const FimoModuleParam *param);
+FimoResult fimo_internal_module_param_get_private(FimoInternalModuleContext *ctx, const FimoModule *module, void *value,
+                                                  FimoModuleParamType *type, const FimoModuleParam *param);
 
 /**
  * Internal setter for a module parameter.
@@ -683,8 +685,9 @@ FimoError fimo_internal_module_param_get_private(FimoInternalModuleContext *ctx,
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_set_inner(FimoInternalModuleContext *ctx, const FimoModule *module,
-                                               const void *value, FimoModuleParamType type, FimoModuleParamData *param);
+FimoResult fimo_internal_module_param_set_inner(FimoInternalModuleContext *ctx, const FimoModule *module,
+                                                const void *value, FimoModuleParamType type,
+                                                FimoModuleParamData *param);
 
 /**
  * Internal getter for a module parameter.
@@ -698,8 +701,8 @@ FimoError fimo_internal_module_param_set_inner(FimoInternalModuleContext *ctx, c
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_module_param_get_inner(FimoInternalModuleContext *ctx, const FimoModule *module, void *value,
-                                               FimoModuleParamType *type, const FimoModuleParamData *param);
+FimoResult fimo_internal_module_param_get_inner(FimoInternalModuleContext *ctx, const FimoModule *module, void *value,
+                                                FimoModuleParamType *type, const FimoModuleParamData *param);
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/internal/tracing.h
+++ b/ffi_library/fimo_std/include/fimo_std/internal/tracing.h
@@ -36,8 +36,8 @@ extern "C" {
             .next = NULL,                                                                                              \
             .metadata = &META_VAR,                                                                                     \
     };                                                                                                                 \
-    FimoError ERROR_VAR = fimo_internal_tracing_event_emit_fmt(CTX, &EVENT_VAR, FMT, __VA_ARGS__);                     \
-    FIMO_ASSERT_FALSE(FIMO_IS_ERROR(ERROR_VAR))                                                                        \
+    FimoResult ERROR_VAR = fimo_internal_tracing_event_emit_fmt(CTX, &EVENT_VAR, FMT, __VA_ARGS__);                    \
+    FIMO_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(ERROR_VAR))                                                                 \
     FIMO_PRAGMA_GCC(GCC diagnostic pop)
 
 /**
@@ -203,23 +203,23 @@ typedef struct FimoInternalTracingContext {
 //// Trampoline functions
 ///////////////////////////////////////////////////////////////////////
 
-FimoError fimo_internal_trampoline_tracing_call_stack_create(void *ctx, FimoTracingCallStack **call_stack);
-FimoError fimo_internal_trampoline_tracing_call_stack_destroy(void *ctx, FimoTracingCallStack *call_stack);
-FimoError fimo_internal_trampoline_tracing_call_stack_switch(void *ctx, FimoTracingCallStack *call_stack,
-                                                             FimoTracingCallStack **old);
-FimoError fimo_internal_trampoline_tracing_call_stack_unblock(void *ctx, FimoTracingCallStack *call_stack);
-FimoError fimo_internal_trampoline_tracing_call_stack_suspend_current(void *ctx, bool block);
-FimoError fimo_internal_trampoline_tracing_call_stack_resume_current(void *ctx);
-FimoError fimo_internal_trampoline_tracing_span_create(void *ctx, const FimoTracingSpanDesc *span_desc,
-                                                       FimoTracingSpan **span, FimoTracingFormat format,
-                                                       const void *data);
-FimoError fimo_internal_trampoline_tracing_span_destroy(void *ctx, FimoTracingSpan *span);
-FimoError fimo_internal_trampoline_tracing_event_emit(void *ctx, const FimoTracingEvent *event,
-                                                      FimoTracingFormat format, const void *data);
+FimoResult fimo_internal_trampoline_tracing_call_stack_create(void *ctx, FimoTracingCallStack **call_stack);
+FimoResult fimo_internal_trampoline_tracing_call_stack_destroy(void *ctx, FimoTracingCallStack *call_stack);
+FimoResult fimo_internal_trampoline_tracing_call_stack_switch(void *ctx, FimoTracingCallStack *call_stack,
+                                                              FimoTracingCallStack **old);
+FimoResult fimo_internal_trampoline_tracing_call_stack_unblock(void *ctx, FimoTracingCallStack *call_stack);
+FimoResult fimo_internal_trampoline_tracing_call_stack_suspend_current(void *ctx, bool block);
+FimoResult fimo_internal_trampoline_tracing_call_stack_resume_current(void *ctx);
+FimoResult fimo_internal_trampoline_tracing_span_create(void *ctx, const FimoTracingSpanDesc *span_desc,
+                                                        FimoTracingSpan **span, FimoTracingFormat format,
+                                                        const void *data);
+FimoResult fimo_internal_trampoline_tracing_span_destroy(void *ctx, FimoTracingSpan *span);
+FimoResult fimo_internal_trampoline_tracing_event_emit(void *ctx, const FimoTracingEvent *event,
+                                                       FimoTracingFormat format, const void *data);
 bool fimo_internal_trampoline_tracing_is_enabled(void *ctx);
-FimoError fimo_internal_trampoline_tracing_register_thread(void *ctx);
-FimoError fimo_internal_trampoline_tracing_unregister_thread(void *ctx);
-FimoError fimo_internal_trampoline_tracing_flush(void *ctx);
+FimoResult fimo_internal_trampoline_tracing_register_thread(void *ctx);
+FimoResult fimo_internal_trampoline_tracing_unregister_thread(void *ctx);
+FimoResult fimo_internal_trampoline_tracing_flush(void *ctx);
 
 ///////////////////////////////////////////////////////////////////////
 //// Tracing Subsystem API
@@ -237,7 +237,7 @@ FimoError fimo_internal_trampoline_tracing_flush(void *ctx);
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_init(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options);
+FimoResult fimo_internal_tracing_init(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options);
 
 /**
  * Destroys the backend.
@@ -269,7 +269,7 @@ void fimo_internal_tracing_cleanup_options(const FimoTracingCreationConfig *opti
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_create(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack);
+FimoResult fimo_internal_tracing_call_stack_create(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack);
 
 /**
  * Destroys an empty call stack.
@@ -287,7 +287,7 @@ FimoError fimo_internal_tracing_call_stack_create(FimoInternalTracingContext *ct
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_destroy(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
+FimoResult fimo_internal_tracing_call_stack_destroy(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
 
 /**
  * Switches the call stack of the current thread.
@@ -309,8 +309,8 @@ FimoError fimo_internal_tracing_call_stack_destroy(FimoInternalTracingContext *c
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_switch(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
-                                                  FimoTracingCallStack **old);
+FimoResult fimo_internal_tracing_call_stack_switch(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
+                                                   FimoTracingCallStack **old);
 
 /**
  * Unblocks a blocked call stack.
@@ -324,7 +324,7 @@ FimoError fimo_internal_tracing_call_stack_switch(FimoInternalTracingContext *ct
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_unblock(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
+FimoResult fimo_internal_tracing_call_stack_unblock(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
 
 /**
  * Marks the current call stack as being suspended.
@@ -343,7 +343,7 @@ FimoError fimo_internal_tracing_call_stack_unblock(FimoInternalTracingContext *c
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_suspend_current(FimoInternalTracingContext *ctx, bool block);
+FimoResult fimo_internal_tracing_call_stack_suspend_current(FimoInternalTracingContext *ctx, bool block);
 
 /**
  * Marks the current call stack as being resumed.
@@ -359,7 +359,7 @@ FimoError fimo_internal_tracing_call_stack_suspend_current(FimoInternalTracingCo
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_resume_current(FimoInternalTracingContext *ctx);
+FimoResult fimo_internal_tracing_call_stack_resume_current(FimoInternalTracingContext *ctx);
 
 /**
  * Creates a new span with the standard formatter and enters it.
@@ -382,8 +382,8 @@ FimoError fimo_internal_tracing_call_stack_resume_current(FimoInternalTracingCon
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_span_create_fmt(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
-                                                FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...)
+FimoResult fimo_internal_tracing_span_create_fmt(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
+                                                 FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...)
         FIMO_PRINT_F_FORMAT_ATTR(4, 5);
 
 /**
@@ -407,9 +407,9 @@ FimoError fimo_internal_tracing_span_create_fmt(FimoInternalTracingContext *ctx,
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_span_create_custom(FimoInternalTracingContext *ctx,
-                                                   const FimoTracingSpanDesc *span_desc, FimoTracingSpan **span,
-                                                   FimoTracingFormat format, const void *data);
+FimoResult fimo_internal_tracing_span_create_custom(FimoInternalTracingContext *ctx,
+                                                    const FimoTracingSpanDesc *span_desc, FimoTracingSpan **span,
+                                                    FimoTracingFormat format, const void *data);
 
 /**
  * Exits and destroys a span.
@@ -428,7 +428,7 @@ FimoError fimo_internal_tracing_span_create_custom(FimoInternalTracingContext *c
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_span_destroy(FimoInternalTracingContext *ctx, FimoTracingSpan *span);
+FimoResult fimo_internal_tracing_span_destroy(FimoInternalTracingContext *ctx, FimoTracingSpan *span);
 
 /**
  * Emits a new event with the standard formatter.
@@ -445,8 +445,8 @@ FimoError fimo_internal_tracing_span_destroy(FimoInternalTracingContext *ctx, Fi
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_event_emit_fmt(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
-                                               FIMO_PRINT_F_FORMAT const char *format, ...)
+FimoResult fimo_internal_tracing_event_emit_fmt(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
+                                                FIMO_PRINT_F_FORMAT const char *format, ...)
         FIMO_PRINT_F_FORMAT_ATTR(3, 4);
 
 /**
@@ -463,8 +463,8 @@ FimoError fimo_internal_tracing_event_emit_fmt(FimoInternalTracingContext *ctx, 
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_event_emit_custom(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
-                                                  FimoTracingFormat format, const void *data);
+FimoResult fimo_internal_tracing_event_emit_custom(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
+                                                   FimoTracingFormat format, const void *data);
 
 /**
  * Checks whether the tracing backend is enabled.
@@ -497,7 +497,7 @@ bool fimo_internal_tracing_is_enabled(FimoInternalTracingContext *ctx);
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_register_thread(FimoInternalTracingContext *ctx);
+FimoResult fimo_internal_tracing_register_thread(FimoInternalTracingContext *ctx);
 
 /**
  * Unregisters the calling thread from the tracing backend.
@@ -511,7 +511,7 @@ FimoError fimo_internal_tracing_register_thread(FimoInternalTracingContext *ctx)
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_unregister_thread(FimoInternalTracingContext *ctx);
+FimoResult fimo_internal_tracing_unregister_thread(FimoInternalTracingContext *ctx);
 
 /**
  * Flushes the streams used for tracing.
@@ -523,7 +523,7 @@ FimoError fimo_internal_tracing_unregister_thread(FimoInternalTracingContext *ct
  * @return Status code.
  */
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_flush(FimoInternalTracingContext *ctx);
+FimoResult fimo_internal_tracing_flush(FimoInternalTracingContext *ctx);
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/memory.h
+++ b/ffi_library/fimo_std/include/fimo_std/memory.h
@@ -46,7 +46,7 @@ typedef struct FimoMallocBuffer {
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-void *fimo_malloc(size_t size, FimoError *error);
+void *fimo_malloc(size_t size, FimoResult *error);
 
 /**
  * Zero-allocate memory.
@@ -66,7 +66,7 @@ void *fimo_malloc(size_t size, FimoError *error);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-void *fimo_calloc(size_t size, FimoError *error);
+void *fimo_calloc(size_t size, FimoResult *error);
 
 /**
  * Allocate memory.
@@ -89,7 +89,7 @@ void *fimo_calloc(size_t size, FimoError *error);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-void *fimo_aligned_alloc(size_t alignment, size_t size, FimoError *error);
+void *fimo_aligned_alloc(size_t alignment, size_t size, FimoResult *error);
 
 /**
  * Allocate memory.
@@ -109,7 +109,7 @@ void *fimo_aligned_alloc(size_t alignment, size_t size, FimoError *error);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoMallocBuffer fimo_malloc_sized(size_t size, FimoError *error);
+FimoMallocBuffer fimo_malloc_sized(size_t size, FimoResult *error);
 
 /**
  * Zero-allocate memory.
@@ -129,7 +129,7 @@ FimoMallocBuffer fimo_malloc_sized(size_t size, FimoError *error);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoMallocBuffer fimo_calloc_sized(size_t size, FimoError *error);
+FimoMallocBuffer fimo_calloc_sized(size_t size, FimoResult *error);
 
 /**
  * Allocate memory.
@@ -154,7 +154,7 @@ FimoMallocBuffer fimo_calloc_sized(size_t size, FimoError *error);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoMallocBuffer fimo_aligned_alloc_sized(size_t alignment, size_t size, FimoError *error);
+FimoMallocBuffer fimo_aligned_alloc_sized(size_t alignment, size_t size, FimoResult *error);
 
 /**
  * Free allocated memory.

--- a/ffi_library/fimo_std/include/fimo_std/module.h
+++ b/ffi_library/fimo_std/include/fimo_std/module.h
@@ -663,7 +663,7 @@ typedef struct FimoModule FimoModule;
  *
  * @return Status code.
  */
-typedef FimoError (*FimoModuleDynamicSymbolConstructor)(const FimoModule *arg0, void **arg1);
+typedef FimoResult (*FimoModuleDynamicSymbolConstructor)(const FimoModule *arg0, void **arg1);
 
 /**
  * Destructor function for a dynamic symbol.
@@ -697,7 +697,7 @@ typedef struct FimoModuleLoadingSet FimoModuleLoadingSet;
  *
  * @return Status code.
  */
-typedef FimoError (*FimoModuleConstructor)(const FimoModule *arg0, FimoModuleLoadingSet *arg1, void **arg2);
+typedef FimoResult (*FimoModuleConstructor)(const FimoModule *arg0, FimoModuleLoadingSet *arg1, void **arg2);
 
 /**
  * Destructor function for a module.
@@ -756,8 +756,8 @@ typedef struct FimoModuleParamData FimoModuleParamData;
  *
  * @return Status code.
  */
-typedef FimoError (*FimoModuleParamSet)(const FimoModule *arg0, const void *arg1, FimoModuleParamType arg2,
-                                        FimoModuleParamData *arg3);
+typedef FimoResult (*FimoModuleParamSet)(const FimoModule *arg0, const void *arg1, FimoModuleParamType arg2,
+                                         FimoModuleParamData *arg3);
 
 /**
  * Getter for a module parameter.
@@ -769,8 +769,8 @@ typedef FimoError (*FimoModuleParamSet)(const FimoModule *arg0, const void *arg1
  *
  * @return Status code.
  */
-typedef FimoError (*FimoModuleParamGet)(const FimoModule *arg0, void *arg1, FimoModuleParamType *arg2,
-                                        const FimoModuleParamData *arg3);
+typedef FimoResult (*FimoModuleParamGet)(const FimoModule *arg0, void *arg1, FimoModuleParamType *arg2,
+                                         const FimoModuleParamData *arg3);
 
 /**
  * Declaration of a module parameter.
@@ -1235,7 +1235,7 @@ typedef struct FimoModuleInfo {
      *
      * Not `NULL`.
      */
-    FimoError (*lock_unload)(const struct FimoModuleInfo *);
+    FimoResult (*lock_unload)(const struct FimoModuleInfo *);
     /**
      * Unlocks a previously locked module, allowing it to be unloaded.
      *
@@ -1253,7 +1253,7 @@ void fimo_impl_module_info_release(const FimoModuleInfo *info);
 FIMO_EXPORT
 bool fimo_impl_module_info_is_loaded(const FimoModuleInfo *info);
 FIMO_EXPORT
-FimoError fimo_impl_module_info_lock_unload(const FimoModuleInfo *info);
+FimoResult fimo_impl_module_info_lock_unload(const FimoModuleInfo *info);
 FIMO_EXPORT
 void fimo_impl_module_info_unlock_unload(const FimoModuleInfo *info);
 #else
@@ -1272,7 +1272,7 @@ static FIMO_INLINE_ALWAYS bool fimo_impl_module_info_is_loaded(const FimoModuleI
     return info->is_loaded(info);
 }
 
-static FIMO_INLINE_ALWAYS FimoError fimo_impl_module_info_lock_unload(const FimoModuleInfo *info) {
+static FIMO_INLINE_ALWAYS FimoResult fimo_impl_module_info_lock_unload(const FimoModuleInfo *info) {
     FIMO_DEBUG_ASSERT(info)
     return info->lock_unload(info);
 }
@@ -1366,44 +1366,44 @@ typedef void (*FimoModuleLoadingErrorCallback)(const FimoModuleExport *arg0, voi
  * Changing the VTable is a breaking change.
  */
 typedef struct FimoModuleVTableV0 {
-    FimoError (*pseudo_module_new)(void *, const FimoModule **);
-    FimoError (*pseudo_module_destroy)(void *, const FimoModule *, FimoContext *);
-    FimoError (*set_new)(void *, FimoModuleLoadingSet **);
-    FimoError (*set_has_module)(void *, FimoModuleLoadingSet *, const char *, bool *);
-    FimoError (*set_has_symbol)(void *, FimoModuleLoadingSet *, const char *, const char *, FimoVersion, bool *);
-    FimoError (*set_append_callback)(void *, FimoModuleLoadingSet *, const char *, FimoModuleLoadingSuccessCallback,
-                                     FimoModuleLoadingErrorCallback, void *);
-    FimoError (*set_append_freestanding_module)(void *, const FimoModule *, FimoModuleLoadingSet *,
-                                                const FimoModuleExport *);
-    FimoError (*set_append_modules)(void *, FimoModuleLoadingSet *, const char *, FimoModuleLoadingFilter, void *,
-                                    void (*)(bool (*)(const FimoModuleExport *, void *), void *), const void *);
-    FimoError (*set_dismiss)(void *, FimoModuleLoadingSet *);
-    FimoError (*set_finish)(void *, FimoModuleLoadingSet *);
-    FimoError (*find_by_name)(void *, const char *, const FimoModuleInfo **);
-    FimoError (*find_by_symbol)(void *, const char *, const char *, FimoVersion, const FimoModuleInfo **);
-    FimoError (*namespace_exists)(void *, const char *, bool *);
-    FimoError (*namespace_include)(void *, const FimoModule *, const char *);
-    FimoError (*namespace_exclude)(void *, const FimoModule *, const char *);
-    FimoError (*namespace_included)(void *, const FimoModule *, const char *, bool *, bool *);
-    FimoError (*acquire_dependency)(void *, const FimoModule *, const FimoModuleInfo *);
-    FimoError (*relinquish_dependency)(void *, const FimoModule *, const FimoModuleInfo *);
-    FimoError (*has_dependency)(void *, const FimoModule *, const FimoModuleInfo *, bool *, bool *);
-    FimoError (*load_symbol)(void *, const FimoModule *, const char *, const char *, FimoVersion,
-                             const FimoModuleRawSymbol **);
-    FimoError (*unload)(void *, const FimoModuleInfo *);
-    FimoError (*param_query)(void *, const char *, const char *, FimoModuleParamType *, FimoModuleParamAccess *,
-                             FimoModuleParamAccess *);
-    FimoError (*param_set_public)(void *, const void *, FimoModuleParamType, const char *, const char *);
-    FimoError (*param_get_public)(void *, void *, FimoModuleParamType *, const char *, const char *);
-    FimoError (*param_set_dependency)(void *, const FimoModule *, const void *, FimoModuleParamType, const char *,
-                                      const char *);
-    FimoError (*param_get_dependency)(void *, const FimoModule *, void *, FimoModuleParamType *, const char *,
-                                      const char *);
-    FimoError (*param_set_private)(void *, const FimoModule *, const void *, FimoModuleParamType, FimoModuleParam *);
-    FimoError (*param_get_private)(void *, const FimoModule *, void *, FimoModuleParamType *, const FimoModuleParam *);
-    FimoError (*param_set_inner)(void *, const FimoModule *, const void *, FimoModuleParamType, FimoModuleParamData *);
-    FimoError (*param_get_inner)(void *, const FimoModule *, void *, FimoModuleParamType *,
-                                 const FimoModuleParamData *);
+    FimoResult (*pseudo_module_new)(void *, const FimoModule **);
+    FimoResult (*pseudo_module_destroy)(void *, const FimoModule *, FimoContext *);
+    FimoResult (*set_new)(void *, FimoModuleLoadingSet **);
+    FimoResult (*set_has_module)(void *, FimoModuleLoadingSet *, const char *, bool *);
+    FimoResult (*set_has_symbol)(void *, FimoModuleLoadingSet *, const char *, const char *, FimoVersion, bool *);
+    FimoResult (*set_append_callback)(void *, FimoModuleLoadingSet *, const char *, FimoModuleLoadingSuccessCallback,
+                                      FimoModuleLoadingErrorCallback, void *);
+    FimoResult (*set_append_freestanding_module)(void *, const FimoModule *, FimoModuleLoadingSet *,
+                                                 const FimoModuleExport *);
+    FimoResult (*set_append_modules)(void *, FimoModuleLoadingSet *, const char *, FimoModuleLoadingFilter, void *,
+                                     void (*)(bool (*)(const FimoModuleExport *, void *), void *), const void *);
+    FimoResult (*set_dismiss)(void *, FimoModuleLoadingSet *);
+    FimoResult (*set_finish)(void *, FimoModuleLoadingSet *);
+    FimoResult (*find_by_name)(void *, const char *, const FimoModuleInfo **);
+    FimoResult (*find_by_symbol)(void *, const char *, const char *, FimoVersion, const FimoModuleInfo **);
+    FimoResult (*namespace_exists)(void *, const char *, bool *);
+    FimoResult (*namespace_include)(void *, const FimoModule *, const char *);
+    FimoResult (*namespace_exclude)(void *, const FimoModule *, const char *);
+    FimoResult (*namespace_included)(void *, const FimoModule *, const char *, bool *, bool *);
+    FimoResult (*acquire_dependency)(void *, const FimoModule *, const FimoModuleInfo *);
+    FimoResult (*relinquish_dependency)(void *, const FimoModule *, const FimoModuleInfo *);
+    FimoResult (*has_dependency)(void *, const FimoModule *, const FimoModuleInfo *, bool *, bool *);
+    FimoResult (*load_symbol)(void *, const FimoModule *, const char *, const char *, FimoVersion,
+                              const FimoModuleRawSymbol **);
+    FimoResult (*unload)(void *, const FimoModuleInfo *);
+    FimoResult (*param_query)(void *, const char *, const char *, FimoModuleParamType *, FimoModuleParamAccess *,
+                              FimoModuleParamAccess *);
+    FimoResult (*param_set_public)(void *, const void *, FimoModuleParamType, const char *, const char *);
+    FimoResult (*param_get_public)(void *, void *, FimoModuleParamType *, const char *, const char *);
+    FimoResult (*param_set_dependency)(void *, const FimoModule *, const void *, FimoModuleParamType, const char *,
+                                       const char *);
+    FimoResult (*param_get_dependency)(void *, const FimoModule *, void *, FimoModuleParamType *, const char *,
+                                       const char *);
+    FimoResult (*param_set_private)(void *, const FimoModule *, const void *, FimoModuleParamType, FimoModuleParam *);
+    FimoResult (*param_get_private)(void *, const FimoModule *, void *, FimoModuleParamType *, const FimoModuleParam *);
+    FimoResult (*param_set_inner)(void *, const FimoModule *, const void *, FimoModuleParamType, FimoModuleParamData *);
+    FimoResult (*param_get_inner)(void *, const FimoModule *, void *, FimoModuleParamType *,
+                                  const FimoModuleParamData *);
 } FimoModuleVTableV0;
 
 /**
@@ -1422,7 +1422,7 @@ typedef struct FimoModuleVTableV0 {
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_pseudo_module_new(FimoContext context, const FimoModule **module);
+FimoResult fimo_module_pseudo_module_new(FimoContext context, const FimoModule **module);
 
 /**
  * Destroys an existing pseudo module.
@@ -1437,7 +1437,7 @@ FimoError fimo_module_pseudo_module_new(FimoContext context, const FimoModule **
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_pseudo_module_destroy(const FimoModule *module, FimoContext *module_context);
+FimoResult fimo_module_pseudo_module_destroy(const FimoModule *module, FimoContext *module_context);
 
 /**
  * Constructs a new empty module set.
@@ -1455,7 +1455,7 @@ FimoError fimo_module_pseudo_module_destroy(const FimoModule *module, FimoContex
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_new(FimoContext context, FimoModuleLoadingSet **module_set);
+FimoResult fimo_module_set_new(FimoContext context, FimoModuleLoadingSet **module_set);
 
 /**
  * Checks whether a module set contains a module.
@@ -1469,8 +1469,8 @@ FimoError fimo_module_set_new(FimoContext context, FimoModuleLoadingSet **module
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_has_module(FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
-                                     bool *has_module);
+FimoResult fimo_module_set_has_module(FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
+                                      bool *has_module);
 
 /**
  * Checks whether a module set contains a symbol.
@@ -1486,8 +1486,8 @@ FimoError fimo_module_set_has_module(FimoContext context, FimoModuleLoadingSet *
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_has_symbol(FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
-                                     const char *ns, FimoVersion version, bool *has_symbol);
+FimoResult fimo_module_set_has_symbol(FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
+                                      const char *ns, FimoVersion version, bool *has_symbol);
 
 /**
  * Adds a status callback to the module set.
@@ -1513,9 +1513,9 @@ FimoError fimo_module_set_has_symbol(FimoContext context, FimoModuleLoadingSet *
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_append_callback(FimoContext context, FimoModuleLoadingSet *module_set,
-                                          const char *module_name, FimoModuleLoadingSuccessCallback on_success,
-                                          FimoModuleLoadingErrorCallback on_error, void *user_data);
+FimoResult fimo_module_set_append_callback(FimoContext context, FimoModuleLoadingSet *module_set,
+                                           const char *module_name, FimoModuleLoadingSuccessCallback on_success,
+                                           FimoModuleLoadingErrorCallback on_error, void *user_data);
 
 /**
  * Adds a freestanding module to the module set.
@@ -1542,8 +1542,8 @@ FimoError fimo_module_set_append_callback(FimoContext context, FimoModuleLoading
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_append_freestanding_module(const FimoModule *module, FimoModuleLoadingSet *module_set,
-                                                     const FimoModuleExport *module_export);
+FimoResult fimo_module_set_append_freestanding_module(const FimoModule *module, FimoModuleLoadingSet *module_set,
+                                                      const FimoModuleExport *module_export);
 
 /**
  * Adds modules to the module set.
@@ -1574,8 +1574,8 @@ FimoError fimo_module_set_append_freestanding_module(const FimoModule *module, F
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_append_modules(FimoContext context, FimoModuleLoadingSet *module_set, const char *module_path,
-                                         FimoModuleLoadingFilter filter, void *filter_data);
+FimoResult fimo_module_set_append_modules(FimoContext context, FimoModuleLoadingSet *module_set,
+                                          const char *module_path, FimoModuleLoadingFilter filter, void *filter_data);
 
 /**
  * Destroys the module set without loading any modules.
@@ -1590,7 +1590,7 @@ FimoError fimo_module_set_append_modules(FimoContext context, FimoModuleLoadingS
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_dismiss(FimoContext context, FimoModuleLoadingSet *module_set);
+FimoResult fimo_module_set_dismiss(FimoContext context, FimoModuleLoadingSet *module_set);
 
 /**
  * Destroys the module set and loads the modules contained in it.
@@ -1610,7 +1610,7 @@ FimoError fimo_module_set_dismiss(FimoContext context, FimoModuleLoadingSet *mod
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_finish(FimoContext context, FimoModuleLoadingSet *module_set);
+FimoResult fimo_module_set_finish(FimoContext context, FimoModuleLoadingSet *module_set);
 
 /**
  * Searches for a module by it's name.
@@ -1626,7 +1626,7 @@ FimoError fimo_module_set_finish(FimoContext context, FimoModuleLoadingSet *modu
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_find_by_name(FimoContext context, const char *name, const FimoModuleInfo **module);
+FimoResult fimo_module_find_by_name(FimoContext context, const char *name, const FimoModuleInfo **module);
 
 /**
  * Searches for a module by a symbol it exports.
@@ -1644,8 +1644,8 @@ FimoError fimo_module_find_by_name(FimoContext context, const char *name, const 
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_find_by_symbol(FimoContext context, const char *name, const char *ns, FimoVersion version,
-                                     const FimoModuleInfo **module);
+FimoResult fimo_module_find_by_symbol(FimoContext context, const char *name, const char *ns, FimoVersion version,
+                                      const FimoModuleInfo **module);
 
 /**
  * Checks for the presence of a namespace in the module backend.
@@ -1661,7 +1661,7 @@ FimoError fimo_module_find_by_symbol(FimoContext context, const char *name, cons
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_exists(FimoContext context, const char *ns, bool *exists);
+FimoResult fimo_module_namespace_exists(FimoContext context, const char *ns, bool *exists);
 
 /**
  * Includes a namespace by the module.
@@ -1677,7 +1677,7 @@ FimoError fimo_module_namespace_exists(FimoContext context, const char *ns, bool
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_include(const FimoModule *module, const char *ns);
+FimoResult fimo_module_namespace_include(const FimoModule *module, const char *ns);
 
 /**
  * Removes a namespace include from the module.
@@ -1695,7 +1695,7 @@ FimoError fimo_module_namespace_include(const FimoModule *module, const char *ns
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_exclude(const FimoModule *module, const char *ns);
+FimoResult fimo_module_namespace_exclude(const FimoModule *module, const char *ns);
 
 /**
  * Checks if a module includes a namespace.
@@ -1717,7 +1717,7 @@ FimoError fimo_module_namespace_exclude(const FimoModule *module, const char *ns
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_included(const FimoModule *module, const char *ns, bool *is_included, bool *is_static);
+FimoResult fimo_module_namespace_included(const FimoModule *module, const char *ns, bool *is_included, bool *is_static);
 
 /**
  * Acquires another module as a dependency.
@@ -1736,7 +1736,7 @@ FimoError fimo_module_namespace_included(const FimoModule *module, const char *n
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_acquire_dependency(const FimoModule *module, const FimoModuleInfo *dependency);
+FimoResult fimo_module_acquire_dependency(const FimoModule *module, const FimoModuleInfo *dependency);
 
 /**
  * Removes a module as a dependency.
@@ -1756,7 +1756,7 @@ FimoError fimo_module_acquire_dependency(const FimoModule *module, const FimoMod
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_relinquish_dependency(const FimoModule *module, const FimoModuleInfo *dependency);
+FimoResult fimo_module_relinquish_dependency(const FimoModule *module, const FimoModuleInfo *dependency);
 
 /**
  * Checks if a module depends on another module.
@@ -1778,8 +1778,8 @@ FimoError fimo_module_relinquish_dependency(const FimoModule *module, const Fimo
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_has_dependency(const FimoModule *module, const FimoModuleInfo *other, bool *has_dependency,
-                                     bool *is_static);
+FimoResult fimo_module_has_dependency(const FimoModule *module, const FimoModuleInfo *other, bool *has_dependency,
+                                      bool *is_static);
 
 /**
  * Loads a symbol from the module backend.
@@ -1803,8 +1803,8 @@ FimoError fimo_module_has_dependency(const FimoModule *module, const FimoModuleI
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_load_symbol(const FimoModule *module, const char *name, const char *ns, FimoVersion version,
-                                  const FimoModuleRawSymbol **symbol);
+FimoResult fimo_module_load_symbol(const FimoModule *module, const char *name, const char *ns, FimoVersion version,
+                                   const FimoModuleRawSymbol **symbol);
 
 /**
  * Unloads a module.
@@ -1823,7 +1823,7 @@ FimoError fimo_module_load_symbol(const FimoModule *module, const char *name, co
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_unload(FimoContext context, const FimoModuleInfo *module);
+FimoResult fimo_module_unload(FimoContext context, const FimoModuleInfo *module);
 
 /**
  * Queries the info of a module parameter.
@@ -1843,8 +1843,9 @@ FimoError fimo_module_unload(FimoContext context, const FimoModuleInfo *module);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_query(FimoContext context, const char *module_name, const char *param,
-                                  FimoModuleParamType *type, FimoModuleParamAccess *read, FimoModuleParamAccess *write);
+FimoResult fimo_module_param_query(FimoContext context, const char *module_name, const char *param,
+                                   FimoModuleParamType *type, FimoModuleParamAccess *read,
+                                   FimoModuleParamAccess *write);
 
 /**
  * Sets a module parameter with public write access.
@@ -1865,8 +1866,8 @@ FimoError fimo_module_param_query(FimoContext context, const char *module_name, 
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_public(FimoContext context, const void *value, FimoModuleParamType type,
-                                       const char *module_name, const char *param);
+FimoResult fimo_module_param_set_public(FimoContext context, const void *value, FimoModuleParamType type,
+                                        const char *module_name, const char *param);
 
 /**
  * Reads a module parameter with public read access.
@@ -1887,8 +1888,8 @@ FimoError fimo_module_param_set_public(FimoContext context, const void *value, F
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_public(FimoContext context, void *value, FimoModuleParamType *type,
-                                       const char *module_name, const char *param);
+FimoResult fimo_module_param_get_public(FimoContext context, void *value, FimoModuleParamType *type,
+                                        const char *module_name, const char *param);
 
 /**
  * Sets a module parameter with dependency write access.
@@ -1909,8 +1910,8 @@ FimoError fimo_module_param_get_public(FimoContext context, void *value, FimoMod
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_dependency(const FimoModule *module, const void *value, FimoModuleParamType type,
-                                           const char *module_name, const char *param);
+FimoResult fimo_module_param_set_dependency(const FimoModule *module, const void *value, FimoModuleParamType type,
+                                            const char *module_name, const char *param);
 
 /**
  * Reads a module parameter with dependency read access.
@@ -1931,8 +1932,8 @@ FimoError fimo_module_param_set_dependency(const FimoModule *module, const void 
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_dependency(const FimoModule *module, void *value, FimoModuleParamType *type,
-                                           const char *module_name, const char *param);
+FimoResult fimo_module_param_get_dependency(const FimoModule *module, void *value, FimoModuleParamType *type,
+                                            const char *module_name, const char *param);
 
 /**
  * Setter for a module parameter.
@@ -1948,8 +1949,8 @@ FimoError fimo_module_param_get_dependency(const FimoModule *module, void *value
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_private(const FimoModule *module, const void *value, FimoModuleParamType type,
-                                        FimoModuleParam *param);
+FimoResult fimo_module_param_set_private(const FimoModule *module, const void *value, FimoModuleParamType type,
+                                         FimoModuleParam *param);
 
 /**
  * Getter for a module parameter.
@@ -1963,8 +1964,8 @@ FimoError fimo_module_param_set_private(const FimoModule *module, const void *va
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_private(const FimoModule *module, void *value, FimoModuleParamType *type,
-                                        const FimoModuleParam *param);
+FimoResult fimo_module_param_get_private(const FimoModule *module, void *value, FimoModuleParamType *type,
+                                         const FimoModuleParam *param);
 
 /**
  * Internal setter for a module parameter.
@@ -1980,8 +1981,8 @@ FimoError fimo_module_param_get_private(const FimoModule *module, void *value, F
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_inner(const FimoModule *module, const void *value, FimoModuleParamType type,
-                                      FimoModuleParamData *param);
+FimoResult fimo_module_param_set_inner(const FimoModule *module, const void *value, FimoModuleParamType type,
+                                       FimoModuleParamData *param);
 
 /**
  * Internal getter for a module parameter.
@@ -1995,8 +1996,8 @@ FimoError fimo_module_param_set_inner(const FimoModule *module, const void *valu
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_inner(const FimoModule *module, void *value, FimoModuleParamType *type,
-                                      const FimoModuleParamData *param);
+FimoResult fimo_module_param_get_inner(const FimoModule *module, void *value, FimoModuleParamType *type,
+                                       const FimoModuleParamData *param);
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/refcount.h
+++ b/ffi_library/fimo_std/include/fimo_std/refcount.h
@@ -190,7 +190,7 @@ bool fimo_decrease_weak_count_atomic(FimoAtomicRefCount *count);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_upgrade_refcount(FimoRefCount *count);
+FimoResult fimo_upgrade_refcount(FimoRefCount *count);
 
 /**
  * Upgrades a weak reference to a strong reference.
@@ -205,7 +205,7 @@ FimoError fimo_upgrade_refcount(FimoRefCount *count);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_upgrade_refcount_atomic(FimoAtomicRefCount *count);
+FimoResult fimo_upgrade_refcount_atomic(FimoAtomicRefCount *count);
 
 /**
  * Downgrades a strong reference to a weak reference.
@@ -222,7 +222,7 @@ FimoError fimo_upgrade_refcount_atomic(FimoAtomicRefCount *count);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_downgrade_refcount(FimoRefCount *count);
+FimoResult fimo_downgrade_refcount(FimoRefCount *count);
 
 /**
  * Downgrades a strong reference to a weak reference.
@@ -239,7 +239,7 @@ FimoError fimo_downgrade_refcount(FimoRefCount *count);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_downgrade_refcount_atomic(FimoAtomicRefCount *count);
+FimoResult fimo_downgrade_refcount_atomic(FimoAtomicRefCount *count);
 
 /**
  * Checks whether there is only one reference.

--- a/ffi_library/fimo_std/include/fimo_std/time.h
+++ b/ffi_library/fimo_std/include/fimo_std/time.h
@@ -288,7 +288,7 @@ FimoU64 fimo_duration_as_nanos(const FimoDuration *duration, FimoU32 *high);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_duration_add(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out);
+FimoResult fimo_duration_add(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out);
 
 /**
  * Adds two durations.
@@ -318,7 +318,7 @@ FimoDuration fimo_duration_saturating_add(const FimoDuration *lhs, const FimoDur
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_duration_sub(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out);
+FimoResult fimo_duration_sub(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out);
 
 /**
  * Subtracts two durations.
@@ -356,7 +356,7 @@ FimoTime fimo_time_now(void);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_elapsed(const FimoTime *time_point, FimoDuration *elapsed);
+FimoResult fimo_time_elapsed(const FimoTime *time_point, FimoDuration *elapsed);
 
 /**
  * Returns the difference between two time points.
@@ -372,8 +372,8 @@ FimoError fimo_time_elapsed(const FimoTime *time_point, FimoDuration *elapsed);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_duration_since(const FimoTime *time_point, const FimoTime *earlier_time_point,
-                                   FimoDuration *duration);
+FimoResult fimo_time_duration_since(const FimoTime *time_point, const FimoTime *earlier_time_point,
+                                    FimoDuration *duration);
 
 /**
  * Adds a duration to a time point.
@@ -389,7 +389,7 @@ FimoError fimo_time_duration_since(const FimoTime *time_point, const FimoTime *e
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_add(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out);
+FimoResult fimo_time_add(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out);
 
 /**
  * Adds a duration to a time point.
@@ -419,7 +419,7 @@ FimoTime fimo_time_saturating_add(const FimoTime *time_point, const FimoDuration
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_sub(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out);
+FimoResult fimo_time_sub(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out);
 
 /**
  * Subtracts a duration from a time point.

--- a/ffi_library/fimo_std/include/fimo_std/tracing.h
+++ b/ffi_library/fimo_std/include/fimo_std/tracing.h
@@ -31,8 +31,8 @@ extern "C" {
             .next = NULL,                                                                                              \
             .metadata = &META_VAR,                                                                                     \
     };                                                                                                                 \
-    FimoError ERROR_VAR = fimo_tracing_event_emit_fmt(CTX, &EVENT_VAR, FMT, __VA_ARGS__);                              \
-    FIMO_ASSERT_FALSE(FIMO_IS_ERROR(ERROR_VAR))                                                                        \
+    FimoResult ERROR_VAR = fimo_tracing_event_emit_fmt(CTX, &EVENT_VAR, FMT, __VA_ARGS__);                             \
+    FIMO_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(ERROR_VAR))                                                                 \
     FIMO_PRAGMA_GCC(GCC diagnostic pop)
 
 /**
@@ -329,7 +329,7 @@ typedef struct FimoTracingEvent {
  * @param arg3 number of written bytes of the formatter
  * @return Status code.
  */
-typedef FimoError (*FimoTracingFormat)(char *, FimoUSize, const void *, FimoUSize *);
+typedef FimoResult (*FimoTracingFormat)(char *, FimoUSize, const void *, FimoUSize *);
 
 /**
  * VTable of a tracing subscriber.
@@ -353,7 +353,7 @@ typedef struct FimoTracingSubscriberVTable {
      * @param arg2 pointer to the new stack
      * @return Status code.
      */
-    FimoError (*call_stack_create)(void *, const FimoTime *, void **);
+    FimoResult (*call_stack_create)(void *, const FimoTime *, void **);
     /**
      * Drops an empty call stack.
      *
@@ -406,7 +406,7 @@ typedef struct FimoTracingSubscriberVTable {
      * @param arg5 the call stack
      * @return Status code.
      */
-    FimoError (*span_push)(void *, const FimoTime *, const FimoTracingSpanDesc *, const char *, FimoUSize, void *);
+    FimoResult (*span_push)(void *, const FimoTime *, const FimoTracingSpanDesc *, const char *, FimoUSize, void *);
     /**
      * Drops a newly created span.
      *
@@ -527,19 +527,19 @@ typedef struct FimoTracingCreationConfig {
  * Changing the VTable is a breaking change.
  */
 typedef struct FimoTracingVTableV0 {
-    FimoError (*call_stack_create)(void *, FimoTracingCallStack **);
-    FimoError (*call_stack_destroy)(void *, FimoTracingCallStack *);
-    FimoError (*call_stack_switch)(void *, FimoTracingCallStack *, FimoTracingCallStack **);
-    FimoError (*call_stack_unblock)(void *, FimoTracingCallStack *);
-    FimoError (*call_stack_suspend_current)(void *, bool);
-    FimoError (*call_stack_resume_current)(void *);
-    FimoError (*span_create)(void *, const FimoTracingSpanDesc *, FimoTracingSpan **, FimoTracingFormat, const void *);
-    FimoError (*span_destroy)(void *, FimoTracingSpan *);
-    FimoError (*event_emit)(void *, const FimoTracingEvent *, FimoTracingFormat, const void *);
+    FimoResult (*call_stack_create)(void *, FimoTracingCallStack **);
+    FimoResult (*call_stack_destroy)(void *, FimoTracingCallStack *);
+    FimoResult (*call_stack_switch)(void *, FimoTracingCallStack *, FimoTracingCallStack **);
+    FimoResult (*call_stack_unblock)(void *, FimoTracingCallStack *);
+    FimoResult (*call_stack_suspend_current)(void *, bool);
+    FimoResult (*call_stack_resume_current)(void *);
+    FimoResult (*span_create)(void *, const FimoTracingSpanDesc *, FimoTracingSpan **, FimoTracingFormat, const void *);
+    FimoResult (*span_destroy)(void *, FimoTracingSpan *);
+    FimoResult (*event_emit)(void *, const FimoTracingEvent *, FimoTracingFormat, const void *);
     bool (*is_enabled)(void *);
-    FimoError (*register_thread)(void *);
-    FimoError (*unregister_thread)(void *);
-    FimoError (*flush)(void *);
+    FimoResult (*register_thread)(void *);
+    FimoResult (*unregister_thread)(void *);
+    FimoResult (*flush)(void *);
 } FimoTracingVTableV0;
 
 /**
@@ -556,7 +556,7 @@ typedef struct FimoTracingVTableV0 {
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_create(FimoContext context, FimoTracingCallStack **call_stack);
+FimoResult fimo_tracing_call_stack_create(FimoContext context, FimoTracingCallStack **call_stack);
 
 /**
  * Destroys an empty call stack.
@@ -575,7 +575,7 @@ FimoError fimo_tracing_call_stack_create(FimoContext context, FimoTracingCallSta
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_destroy(FimoContext context, FimoTracingCallStack *call_stack);
+FimoResult fimo_tracing_call_stack_destroy(FimoContext context, FimoTracingCallStack *call_stack);
 
 /**
  * Switches the call stack of the current thread.
@@ -598,8 +598,8 @@ FimoError fimo_tracing_call_stack_destroy(FimoContext context, FimoTracingCallSt
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_switch(FimoContext context, FimoTracingCallStack *call_stack,
-                                         FimoTracingCallStack **old);
+FimoResult fimo_tracing_call_stack_switch(FimoContext context, FimoTracingCallStack *call_stack,
+                                          FimoTracingCallStack **old);
 
 /**
  * Unblocks a blocked call stack.
@@ -614,7 +614,7 @@ FimoError fimo_tracing_call_stack_switch(FimoContext context, FimoTracingCallSta
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_unblock(FimoContext context, FimoTracingCallStack *call_stack);
+FimoResult fimo_tracing_call_stack_unblock(FimoContext context, FimoTracingCallStack *call_stack);
 
 /**
  * Marks the current call stack as being suspended.
@@ -634,7 +634,7 @@ FimoError fimo_tracing_call_stack_unblock(FimoContext context, FimoTracingCallSt
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_suspend_current(FimoContext context, bool block);
+FimoResult fimo_tracing_call_stack_suspend_current(FimoContext context, bool block);
 
 /**
  * Marks the current call stack as being resumed.
@@ -651,7 +651,7 @@ FimoError fimo_tracing_call_stack_suspend_current(FimoContext context, bool bloc
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_resume_current(FimoContext context);
+FimoResult fimo_tracing_call_stack_resume_current(FimoContext context);
 
 /**
  * Creates a new span with the standard formatter and enters it.
@@ -675,8 +675,8 @@ FimoError fimo_tracing_call_stack_resume_current(FimoContext context);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_span_create_fmt(FimoContext context, const FimoTracingSpanDesc *span_desc,
-                                       FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...)
+FimoResult fimo_tracing_span_create_fmt(FimoContext context, const FimoTracingSpanDesc *span_desc,
+                                        FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...)
         FIMO_PRINT_F_FORMAT_ATTR(4, 5);
 
 /**
@@ -701,8 +701,8 @@ FimoError fimo_tracing_span_create_fmt(FimoContext context, const FimoTracingSpa
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_span_create_custom(FimoContext context, const FimoTracingSpanDesc *span_desc,
-                                          FimoTracingSpan **span, FimoTracingFormat format, const void *data);
+FimoResult fimo_tracing_span_create_custom(FimoContext context, const FimoTracingSpanDesc *span_desc,
+                                           FimoTracingSpan **span, FimoTracingFormat format, const void *data);
 
 /**
  * Exits and destroys a span.
@@ -722,7 +722,7 @@ FimoError fimo_tracing_span_create_custom(FimoContext context, const FimoTracing
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_span_destroy(FimoContext context, FimoTracingSpan *span);
+FimoResult fimo_tracing_span_destroy(FimoContext context, FimoTracingSpan *span);
 
 /**
  * Emits a new event with the standard formatter.
@@ -740,8 +740,8 @@ FimoError fimo_tracing_span_destroy(FimoContext context, FimoTracingSpan *span);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_event_emit_fmt(FimoContext context, const FimoTracingEvent *event,
-                                      FIMO_PRINT_F_FORMAT const char *format, ...) FIMO_PRINT_F_FORMAT_ATTR(3, 4);
+FimoResult fimo_tracing_event_emit_fmt(FimoContext context, const FimoTracingEvent *event,
+                                       FIMO_PRINT_F_FORMAT const char *format, ...) FIMO_PRINT_F_FORMAT_ATTR(3, 4);
 
 /**
  * Emits a new event with a custom formatter.
@@ -758,8 +758,8 @@ FimoError fimo_tracing_event_emit_fmt(FimoContext context, const FimoTracingEven
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_event_emit_custom(FimoContext context, const FimoTracingEvent *event, FimoTracingFormat format,
-                                         const void *data);
+FimoResult fimo_tracing_event_emit_custom(FimoContext context, const FimoTracingEvent *event, FimoTracingFormat format,
+                                          const void *data);
 
 /**
  * Checks whether the tracing backend is enabled.
@@ -794,7 +794,7 @@ bool fimo_tracing_is_enabled(FimoContext context);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_register_thread(FimoContext context);
+FimoResult fimo_tracing_register_thread(FimoContext context);
 
 /**
  * Unregisters the calling thread from the tracing backend.
@@ -809,7 +809,7 @@ FimoError fimo_tracing_register_thread(FimoContext context);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_unregister_thread(FimoContext context);
+FimoResult fimo_tracing_unregister_thread(FimoContext context);
 
 /**
  * Flushes the streams used for tracing.
@@ -822,7 +822,7 @@ FimoError fimo_tracing_unregister_thread(FimoContext context);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_flush(FimoContext context);
+FimoResult fimo_tracing_flush(FimoContext context);
 
 #ifdef __cplusplus
 }

--- a/ffi_library/fimo_std/include/fimo_std/version.h
+++ b/ffi_library/fimo_std/include/fimo_std/version.h
@@ -76,7 +76,7 @@ typedef struct FimoVersion {
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_version_parse_str(const char *str, size_t str_len, FimoVersion *version);
+FimoResult fimo_version_parse_str(const char *str, size_t str_len, FimoVersion *version);
 
 /**
  * Calculates the string length required to represent the version as a string.
@@ -125,7 +125,7 @@ size_t fimo_version_str_len_full(const FimoVersion *version);
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_version_write_str(const FimoVersion *version, char *str, size_t str_len, size_t *written);
+FimoResult fimo_version_write_str(const FimoVersion *version, char *str, size_t str_len, size_t *written);
 
 /**
  * Represents the version as a string.
@@ -144,7 +144,7 @@ FimoError fimo_version_write_str(const FimoVersion *version, char *str, size_t s
  */
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_version_write_str_long(const FimoVersion *version, char *str, size_t str_len, size_t *written);
+FimoResult fimo_version_write_str_long(const FimoVersion *version, char *str, size_t str_len, size_t *written);
 
 /**
  * Compares two versions.

--- a/ffi_library/fimo_std/src/array_list.c
+++ b/ffi_library/fimo_std/src/array_list.c
@@ -21,8 +21,8 @@ FimoArrayList fimo_array_list_new(void) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_with_capacity(FimoUSize capacity, const FimoUSize elem_size, const FimoUSize elem_align,
-                                        FimoArrayList *array) {
+FimoResult fimo_array_list_with_capacity(FimoUSize capacity, const FimoUSize elem_size, const FimoUSize elem_align,
+                                         FimoArrayList *array) {
     FIMO_DEBUG_ASSERT(array)
     capacity = fimo_usize_next_power_of_two(capacity);
     return fimo_array_list_with_capacity_exact(capacity, elem_size, elem_align, array);
@@ -30,8 +30,8 @@ FimoError fimo_array_list_with_capacity(FimoUSize capacity, const FimoUSize elem
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_with_capacity_exact(const FimoUSize capacity, const FimoUSize elem_size,
-                                              const FimoUSize elem_align, FimoArrayList *array) {
+FimoResult fimo_array_list_with_capacity_exact(const FimoUSize capacity, const FimoUSize elem_size,
+                                               const FimoUSize elem_align, FimoArrayList *array) {
     FIMO_DEBUG_ASSERT(array)
     if (capacity > MAX_CAPACITY_) {
         return FIMO_EINVAL;
@@ -43,9 +43,9 @@ FimoError fimo_array_list_with_capacity_exact(const FimoUSize capacity, const Fi
     }
     const FimoUSize buffer_size = tmp.value;
 
-    FimoError error = FIMO_EOK;
+    FimoResult error = FIMO_EOK;
     array->elements = fimo_aligned_alloc(elem_align, buffer_size, &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
     array->capacity = capacity;
@@ -71,8 +71,8 @@ void fimo_array_list_free(FimoArrayList *array, const FimoUSize elem_size, const
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_reserve(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
-                                  const FimoUSize additional, const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_reserve(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
+                                   const FimoUSize additional, const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array)
     const FimoIntOverflowCheckUSize tmp = fimo_usize_overflowing_add(additional, array->size);
     if (tmp.overflow) {
@@ -88,8 +88,8 @@ FimoError fimo_array_list_reserve(FimoArrayList *array, const FimoUSize elem_siz
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_reserve_exact(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
-                                        const FimoUSize additional, const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_reserve_exact(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
+                                         const FimoUSize additional, const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array)
     const FimoIntOverflowCheckUSize tmp = fimo_usize_overflowing_add(additional, array->size);
     if (tmp.overflow) {
@@ -105,9 +105,9 @@ FimoError fimo_array_list_reserve_exact(FimoArrayList *array, const FimoUSize el
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_set_capacity(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
-                                       FimoUSize capacity, const FimoArrayListMoveFunc move_func,
-                                       const FimoArrayListDropFunc drop_func) {
+FimoResult fimo_array_list_set_capacity(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
+                                        FimoUSize capacity, const FimoArrayListMoveFunc move_func,
+                                        const FimoArrayListDropFunc drop_func) {
     FIMO_DEBUG_ASSERT(array)
     capacity = fimo_usize_next_power_of_two(capacity);
     return fimo_array_list_set_capacity_exact(array, elem_size, elem_align, capacity, move_func, drop_func);
@@ -115,10 +115,10 @@ FimoError fimo_array_list_set_capacity(FimoArrayList *array, const FimoUSize ele
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_set_capacity_exact(FimoArrayList *array, const FimoUSize elem_size,
-                                             const FimoUSize elem_align, const FimoUSize capacity,
-                                             const FimoArrayListMoveFunc move_func,
-                                             const FimoArrayListDropFunc drop_func) {
+FimoResult fimo_array_list_set_capacity_exact(FimoArrayList *array, const FimoUSize elem_size,
+                                              const FimoUSize elem_align, const FimoUSize capacity,
+                                              const FimoArrayListMoveFunc move_func,
+                                              const FimoArrayListDropFunc drop_func) {
     FIMO_DEBUG_ASSERT(array)
     if (capacity > MAX_CAPACITY_) {
         return FIMO_EINVAL;
@@ -130,9 +130,9 @@ FimoError fimo_array_list_set_capacity_exact(FimoArrayList *array, const FimoUSi
     }
     const FimoUSize buffer_size = tmp.value;
 
-    FimoError error = FIMO_EOK;
+    FimoResult error = FIMO_EOK;
     void *elements = fimo_aligned_alloc(elem_align, buffer_size, &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
@@ -180,7 +180,7 @@ FimoError fimo_array_list_set_capacity_exact(FimoArrayList *array, const FimoUSi
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_set_len(FimoArrayList *array, const FimoUSize len) {
+FimoResult fimo_array_list_set_len(FimoArrayList *array, const FimoUSize len) {
     FIMO_DEBUG_ASSERT(array)
     if (len > array->capacity) {
         return FIMO_EINVAL;
@@ -213,38 +213,38 @@ FimoUSize fimo_array_list_capacity(const FimoArrayList *array) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_peek_front(const FimoArrayList *array, const FimoUSize elem_size, const void **element) {
+FimoResult fimo_array_list_peek_front(const FimoArrayList *array, const FimoUSize elem_size, const void **element) {
     FIMO_DEBUG_ASSERT(array && element)
     return fimo_array_list_get(array, 0, elem_size, element);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_peek_back(const FimoArrayList *array, const FimoUSize elem_size, const void **element) {
+FimoResult fimo_array_list_peek_back(const FimoArrayList *array, const FimoUSize elem_size, const void **element) {
     FIMO_DEBUG_ASSERT(array && element)
     return fimo_array_list_get(array, array->size - 1, elem_size, element);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_pop_front(FimoArrayList *array, const FimoUSize elem_size, void *element,
-                                    const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_pop_front(FimoArrayList *array, const FimoUSize elem_size, void *element,
+                                     const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array && element)
     return fimo_array_list_remove(array, 0, elem_size, element, move_func);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_pop_back(FimoArrayList *array, const FimoUSize elem_size, void *element,
-                                   const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_pop_back(FimoArrayList *array, const FimoUSize elem_size, void *element,
+                                    const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array && element)
     return fimo_array_list_remove(array, array->size - 1, elem_size, element, move_func);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_get(const FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size,
-                              const void **element) {
+FimoResult fimo_array_list_get(const FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size,
+                               const void **element) {
     FIMO_DEBUG_ASSERT(array && element)
     if (array->size <= index) {
         return FIMO_EINVAL;
@@ -258,32 +258,32 @@ FimoError fimo_array_list_get(const FimoArrayList *array, const FimoUSize index,
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_push(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
-                               void *element, const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_push(FimoArrayList *array, const FimoUSize elem_size, const FimoUSize elem_align,
+                                void *element, const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array && element)
     return fimo_array_list_insert(array, array->size, elem_size, elem_align, element, move_func);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_try_push(FimoArrayList *array, const FimoUSize elem_size, void *element,
-                                   const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_try_push(FimoArrayList *array, const FimoUSize elem_size, void *element,
+                                    const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array && element)
     return fimo_array_list_try_insert(array, array->size, elem_size, element, move_func);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_insert(FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size,
-                                 const FimoUSize elem_align, void *element, const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_insert(FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size,
+                                  const FimoUSize elem_align, void *element, const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array && element)
     if (array->size < index) {
         return FIMO_EINVAL;
     }
 
     if (array->size == array->capacity) {
-        const FimoError error = fimo_array_list_reserve(array, elem_size, elem_align, 1, move_func);
-        if (FIMO_IS_ERROR(error)) {
+        const FimoResult error = fimo_array_list_reserve(array, elem_size, elem_align, 1, move_func);
+        if (FIMO_RESULT_IS_ERROR(error)) {
             return error;
         }
     }
@@ -293,8 +293,8 @@ FimoError fimo_array_list_insert(FimoArrayList *array, const FimoUSize index, co
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_try_insert(FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size,
-                                     void *element, const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_try_insert(FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size,
+                                      void *element, const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array && element)
     if (array->size < index || array->capacity == array->size) {
         return FIMO_EINVAL;
@@ -335,8 +335,8 @@ FimoError fimo_array_list_try_insert(FimoArrayList *array, const FimoUSize index
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_array_list_remove(FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size, void *element,
-                                 const FimoArrayListMoveFunc move_func) {
+FimoResult fimo_array_list_remove(FimoArrayList *array, const FimoUSize index, const FimoUSize elem_size, void *element,
+                                  const FimoArrayListMoveFunc move_func) {
     FIMO_DEBUG_ASSERT(array && element)
     if (array->size <= index) {
         return FIMO_EINVAL;

--- a/ffi_library/fimo_std/src/context.c
+++ b/ffi_library/fimo_std/src/context.c
@@ -9,13 +9,13 @@ static const FimoVersion FIMO_REQUIRED_VERSION =
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_context_init(const FimoBaseStructIn **options, FimoContext *context) {
+FimoResult fimo_context_init(const FimoBaseStructIn **options, FimoContext *context) {
     return fimo_internal_context_init(options, context);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_context_check_version(const FimoContext context) {
+FimoResult fimo_context_check_version(const FimoContext context) {
     const FimoContextVTableHeader *vtable = context.vtable;
     return vtable->check_version(context.data, &FIMO_REQUIRED_VERSION);
 }

--- a/ffi_library/fimo_std/src/error.c
+++ b/ffi_library/fimo_std/src/error.c
@@ -1261,18 +1261,12 @@ const FimoResultVTable FIMO_IMPL_RESULT_DYNAMIC_STRING_VTABLE = {
 };
 
 static FimoResultString error_name_error_code_(void *data) {
-    FIMO_PRAGMA_MSVC(warning(push))
-    FIMO_PRAGMA_MSVC(warning(disable : 4311))
-    FimoErrorCode error = (int)data;
-    FIMO_PRAGMA_MSVC(warning(pop))
+    FimoErrorCode error = (int)(intptr_t)data;
     return (FimoResultString){.str = fimo_error_code_name(error), .release = NULL};
 }
 
 static FimoResultString error_description_error_code_(void *data) {
-    FIMO_PRAGMA_MSVC(warning(push))
-    FIMO_PRAGMA_MSVC(warning(disable : 4311))
-    FimoErrorCode error = (int)data;
-    FIMO_PRAGMA_MSVC(warning(pop))
+    FimoErrorCode error = (int)(intptr_t)data;
     return (FimoResultString){.str = fimo_error_code_description(error), .release = NULL};
 }
 
@@ -1290,10 +1284,7 @@ static void free_string_system_(const char *str) { LocalFree((char *)str); }
 #endif
 
 static FimoResultString error_name_system_(void *data) {
-    FIMO_PRAGMA_MSVC(warning(push))
-    FIMO_PRAGMA_MSVC(warning(disable : 4311))
-    FimoSystemErrorCode error = (FimoSystemErrorCode)data;
-    FIMO_PRAGMA_MSVC(warning(pop))
+    FimoSystemErrorCode error = (FimoSystemErrorCode)(intptr_t)data;
 #ifdef _WIN32
     LPSTR error_name_template = "SystemError(%1!l!)";
     DWORD_PTR error_name_args[] = {(DWORD_PTR)error};
@@ -1305,16 +1296,13 @@ static FimoResultString error_name_system_(void *data) {
     }
     return (FimoResultString){.str = error_name, .release = free_string_system_};
 #else
-    FimoErrorCode code = fimo_error_from_errno(error);
-    return {.str = fimo_error_code_name(code), .release = NULL};
+    FimoErrorCode code = fimo_error_code_from_errno(error);
+    return (FimoResultString){.str = fimo_error_code_name(code), .release = NULL};
 #endif
 }
 
 static FimoResultString error_description_system_(void *data) {
-    FIMO_PRAGMA_MSVC(warning(push))
-    FIMO_PRAGMA_MSVC(warning(disable : 4311))
-    FimoSystemErrorCode error = (FimoSystemErrorCode)data;
-    FIMO_PRAGMA_MSVC(warning(pop))
+    FimoSystemErrorCode error = (FimoSystemErrorCode)(intptr_t)data;
 #ifdef _WIN32
     LPSTR error_description = NULL;
     if (!FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -1323,8 +1311,8 @@ static FimoResultString error_description_system_(void *data) {
     }
     return (FimoResultString){.str = error_description, .release = free_string_system_};
 #else
-    FimoErrorCode code = fimo_error_from_errno(error);
-    return {.str = fimo_error_code_description(code), .release = NULL};
+    FimoErrorCode code = fimo_error_code_from_errno(error);
+    return (FimoResultString){.str = fimo_error_code_description(code), .release = NULL};
 #endif
 }
 

--- a/ffi_library/fimo_std/src/error.c
+++ b/ffi_library/fimo_std/src/error.c
@@ -2,1221 +2,1343 @@
 
 #include <errno.h>
 #include <stddef.h>
+#include <string.h>
+
+#include "fimo_std/memory.h"
 
 FIMO_EXPORT
 FIMO_MUST_USE
-const char *fimo_strerrorname(const FimoError errnum, FimoError *err) {
-    if (err) {
-        *err = FIMO_EOK;
-    }
-
+const char *fimo_error_code_name(const FimoErrorCode errnum) {
     switch (errnum) {
-        case FIMO_EOK:
-            return FIMO_STRINGIFY(FIMO_EOK);
-        case FIMO_E2BIG:
-            return FIMO_STRINGIFY(FIMO_E2BIG);
-        case FIMO_EACCES:
-            return FIMO_STRINGIFY(FIMO_EACCES);
-        case FIMO_EADDRINUSE:
-            return FIMO_STRINGIFY(FIMO_EADDRINUSE);
-        case FIMO_EADDRNOTAVAIL:
-            return FIMO_STRINGIFY(FIMO_EADDRNOTAVAIL);
-        case FIMO_EAFNOSUPPORT:
-            return FIMO_STRINGIFY(FIMO_EAFNOSUPPORT);
-        case FIMO_EAGAIN:
-            return FIMO_STRINGIFY(FIMO_EAGAIN);
-        case FIMO_EALREADY:
-            return FIMO_STRINGIFY(FIMO_EALREADY);
-        case FIMO_EBADE:
-            return FIMO_STRINGIFY(FIMO_EBADE);
-        case FIMO_EBADF:
-            return FIMO_STRINGIFY(FIMO_EBADF);
-        case FIMO_EBADFD:
-            return FIMO_STRINGIFY(FIMO_EBADFD);
-        case FIMO_EBADMSG:
-            return FIMO_STRINGIFY(FIMO_EBADMSG);
-        case FIMO_EBADR:
-            return FIMO_STRINGIFY(FIMO_EBADR);
-        case FIMO_EBADRQC:
-            return FIMO_STRINGIFY(FIMO_EBADRQC);
-        case FIMO_EBADSLT:
-            return FIMO_STRINGIFY(FIMO_EBADSLT);
-        case FIMO_EBUSY:
-            return FIMO_STRINGIFY(FIMO_EBUSY);
-        case FIMO_ECANCELED:
-            return FIMO_STRINGIFY(FIMO_ECANCELED);
-        case FIMO_ECHILD:
-            return FIMO_STRINGIFY(FIMO_ECHILD);
-        case FIMO_ECHRNG:
-            return FIMO_STRINGIFY(FIMO_ECHRNG);
-        case FIMO_ECOMM:
-            return FIMO_STRINGIFY(FIMO_ECOMM);
-        case FIMO_ECONNABORTED:
-            return FIMO_STRINGIFY(FIMO_ECONNABORTED);
-        case FIMO_ECONNREFUSED:
-            return FIMO_STRINGIFY(FIMO_ECONNREFUSED);
-        case FIMO_ECONNRESET:
-            return FIMO_STRINGIFY(FIMO_ECONNRESET);
-        case FIMO_EDEADLK:
-            return FIMO_STRINGIFY(FIMO_EDEADLK);
-        case FIMO_EDEADLOCK:
-            return FIMO_STRINGIFY(FIMO_EDEADLOCK);
-        case FIMO_EDESTADDRREQ:
-            return FIMO_STRINGIFY(FIMO_EDESTADDRREQ);
-        case FIMO_EDOM:
-            return FIMO_STRINGIFY(FIMO_EDOM);
-        case FIMO_EDQUOT:
-            return FIMO_STRINGIFY(FIMO_EDQUOT);
-        case FIMO_EEXIST:
-            return FIMO_STRINGIFY(FIMO_EEXIST);
-        case FIMO_EFAULT:
-            return FIMO_STRINGIFY(FIMO_EFAULT);
-        case FIMO_EFBIG:
-            return FIMO_STRINGIFY(FIMO_EFBIG);
-        case FIMO_EHOSTDOWN:
-            return FIMO_STRINGIFY(FIMO_EHOSTDOWN);
-        case FIMO_EHOSTUNREACH:
-            return FIMO_STRINGIFY(FIMO_EHOSTUNREACH);
-        case FIMO_EHWPOISON:
-            return FIMO_STRINGIFY(FIMO_EHWPOISON);
-        case FIMO_EIDRM:
-            return FIMO_STRINGIFY(FIMO_EIDRM);
-        case FIMO_EILSEQ:
-            return FIMO_STRINGIFY(FIMO_EILSEQ);
-        case FIMO_EINPROGRESS:
-            return FIMO_STRINGIFY(FIMO_EINPROGRESS);
-        case FIMO_EINTR:
-            return FIMO_STRINGIFY(FIMO_EINTR);
-        case FIMO_EINVAL:
-            return FIMO_STRINGIFY(FIMO_EINVAL);
-        case FIMO_EIO:
-            return FIMO_STRINGIFY(FIMO_EIO);
-        case FIMO_EISCONN:
-            return FIMO_STRINGIFY(FIMO_EISCONN);
-        case FIMO_EISDIR:
-            return FIMO_STRINGIFY(FIMO_EISDIR);
-        case FIMO_EISNAM:
-            return FIMO_STRINGIFY(FIMO_EISNAM);
-        case FIMO_EKEYEXPIRED:
-            return FIMO_STRINGIFY(FIMO_EKEYEXPIRED);
-        case FIMO_EKEYREJECTED:
-            return FIMO_STRINGIFY(FIMO_EKEYREJECTED);
-        case FIMO_EKEYREVOKED:
-            return FIMO_STRINGIFY(FIMO_EKEYREVOKED);
-        case FIMO_EL2HLT:
-            return FIMO_STRINGIFY(FIMO_EL2HLT);
-        case FIMO_EL2NSYNC:
-            return FIMO_STRINGIFY(FIMO_EL2NSYNC);
-        case FIMO_EL3HLT:
-            return FIMO_STRINGIFY(FIMO_EL3HLT);
-        case FIMO_EL3RST:
-            return FIMO_STRINGIFY(FIMO_EL3RST);
-        case FIMO_ELIBACC:
-            return FIMO_STRINGIFY(FIMO_ELIBACC);
-        case FIMO_ELIBBAD:
-            return FIMO_STRINGIFY(FIMO_ELIBBAD);
-        case FIMO_ELIBMAX:
-            return FIMO_STRINGIFY(FIMO_ELIBMAX);
-        case FIMO_ELIBSCN:
-            return FIMO_STRINGIFY(FIMO_ELIBSCN);
-        case FIMO_ELIBEXEC:
-            return FIMO_STRINGIFY(FIMO_ELIBEXEC);
-        case FIMO_ELNRNG:
-            return FIMO_STRINGIFY(FIMO_ELNRNG);
-        case FIMO_ELOOP:
-            return FIMO_STRINGIFY(FIMO_ELOOP);
-        case FIMO_EMEDIUMTYPE:
-            return FIMO_STRINGIFY(FIMO_EMEDIUMTYPE);
-        case FIMO_EMFILE:
-            return FIMO_STRINGIFY(FIMO_EMFILE);
-        case FIMO_EMLINK:
-            return FIMO_STRINGIFY(FIMO_EMLINK);
-        case FIMO_EMSGSIZE:
-            return FIMO_STRINGIFY(FIMO_EMSGSIZE);
-        case FIMO_EMULTIHOP:
-            return FIMO_STRINGIFY(FIMO_EMULTIHOP);
-        case FIMO_ENAMETOOLONG:
-            return FIMO_STRINGIFY(FIMO_ENAMETOOLONG);
-        case FIMO_ENETDOWN:
-            return FIMO_STRINGIFY(FIMO_ENETDOWN);
-        case FIMO_ENETRESET:
-            return FIMO_STRINGIFY(FIMO_ENETRESET);
-        case FIMO_ENETUNREACH:
-            return FIMO_STRINGIFY(FIMO_ENETUNREACH);
-        case FIMO_ENFILE:
-            return FIMO_STRINGIFY(FIMO_ENFILE);
-        case FIMO_ENOANO:
-            return FIMO_STRINGIFY(FIMO_ENOANO);
-        case FIMO_ENOBUFS:
-            return FIMO_STRINGIFY(FIMO_ENOBUFS);
-        case FIMO_ENODATA:
-            return FIMO_STRINGIFY(FIMO_ENODATA);
-        case FIMO_ENODEV:
-            return FIMO_STRINGIFY(FIMO_ENODEV);
-        case FIMO_ENOENT:
-            return FIMO_STRINGIFY(FIMO_ENOENT);
-        case FIMO_ENOEXEC:
-            return FIMO_STRINGIFY(FIMO_ENOEXEC);
-        case FIMO_ENOKEY:
-            return FIMO_STRINGIFY(FIMO_ENOKEY);
-        case FIMO_ENOLCK:
-            return FIMO_STRINGIFY(FIMO_ENOLCK);
-        case FIMO_ENOLINK:
-            return FIMO_STRINGIFY(FIMO_ENOLINK);
-        case FIMO_ENOMEDIUM:
-            return FIMO_STRINGIFY(FIMO_ENOMEDIUM);
-        case FIMO_ENOMEM:
-            return FIMO_STRINGIFY(FIMO_ENOMEM);
-        case FIMO_ENOMSG:
-            return FIMO_STRINGIFY(FIMO_ENOMSG);
-        case FIMO_ENONET:
-            return FIMO_STRINGIFY(FIMO_ENONET);
-        case FIMO_ENOPKG:
-            return FIMO_STRINGIFY(FIMO_ENOPKG);
-        case FIMO_ENOPROTOOPT:
-            return FIMO_STRINGIFY(FIMO_ENOPROTOOPT);
-        case FIMO_ENOSPC:
-            return FIMO_STRINGIFY(FIMO_ENOSPC);
-        case FIMO_ENOSR:
-            return FIMO_STRINGIFY(FIMO_ENOSR);
-        case FIMO_ENOSTR:
-            return FIMO_STRINGIFY(FIMO_ENOSTR);
-        case FIMO_ENOSYS:
-            return FIMO_STRINGIFY(FIMO_ENOSYS);
-        case FIMO_ENOTBLK:
-            return FIMO_STRINGIFY(FIMO_ENOTBLK);
-        case FIMO_ENOTCONN:
-            return FIMO_STRINGIFY(FIMO_ENOTCONN);
-        case FIMO_ENOTDIR:
-            return FIMO_STRINGIFY(FIMO_ENOTDIR);
-        case FIMO_ENOTEMPTY:
-            return FIMO_STRINGIFY(FIMO_ENOTEMPTY);
-        case FIMO_ENOTRECOVERABLE:
-            return FIMO_STRINGIFY(FIMO_ENOTRECOVERABLE);
-        case FIMO_ENOTSOCK:
-            return FIMO_STRINGIFY(FIMO_ENOTSOCK);
-        case FIMO_ENOTSUP:
-            return FIMO_STRINGIFY(FIMO_ENOTSUP);
-        case FIMO_ENOTTY:
-            return FIMO_STRINGIFY(FIMO_ENOTTY);
-        case FIMO_ENOTUNIQ:
-            return FIMO_STRINGIFY(FIMO_ENOTUNIQ);
-        case FIMO_ENXIO:
-            return FIMO_STRINGIFY(FIMO_ENXIO);
-        case FIMO_EOPNOTSUPP:
-            return FIMO_STRINGIFY(FIMO_EOPNOTSUPP);
-        case FIMO_EOVERFLOW:
-            return FIMO_STRINGIFY(FIMO_EOVERFLOW);
-        case FIMO_EOWNERDEAD:
-            return FIMO_STRINGIFY(FIMO_EOWNERDEAD);
-        case FIMO_EPERM:
-            return FIMO_STRINGIFY(FIMO_EPERM);
-        case FIMO_EPFNOSUPPORT:
-            return FIMO_STRINGIFY(FIMO_EPFNOSUPPORT);
-        case FIMO_EPIPE:
-            return FIMO_STRINGIFY(FIMO_EPIPE);
-        case FIMO_EPROTO:
-            return FIMO_STRINGIFY(FIMO_EPROTO);
-        case FIMO_EPROTONOSUPPORT:
-            return FIMO_STRINGIFY(FIMO_EPROTONOSUPPORT);
-        case FIMO_EPROTOTYPE:
-            return FIMO_STRINGIFY(FIMO_EPROTOTYPE);
-        case FIMO_ERANGE:
-            return FIMO_STRINGIFY(FIMO_ERANGE);
-        case FIMO_EREMCHG:
-            return FIMO_STRINGIFY(FIMO_EREMCHG);
-        case FIMO_EREMOTE:
-            return FIMO_STRINGIFY(FIMO_EREMOTE);
-        case FIMO_EREMOTEIO:
-            return FIMO_STRINGIFY(FIMO_EREMOTEIO);
-        case FIMO_ERESTART:
-            return FIMO_STRINGIFY(FIMO_ERESTART);
-        case FIMO_ERFKILL:
-            return FIMO_STRINGIFY(FIMO_ERFKILL);
-        case FIMO_EROFS:
-            return FIMO_STRINGIFY(FIMO_EROFS);
-        case FIMO_ESHUTDOWN:
-            return FIMO_STRINGIFY(FIMO_ESHUTDOWN);
-        case FIMO_ESPIPE:
-            return FIMO_STRINGIFY(FIMO_ESPIPE);
-        case FIMO_ESOCKTNOSUPPORT:
-            return FIMO_STRINGIFY(FIMO_ESOCKTNOSUPPORT);
-        case FIMO_ESRCH:
-            return FIMO_STRINGIFY(FIMO_ESRCH);
-        case FIMO_ESTALE:
-            return FIMO_STRINGIFY(FIMO_ESTALE);
-        case FIMO_ESTRPIPE:
-            return FIMO_STRINGIFY(FIMO_ESTRPIPE);
-        case FIMO_ETIME:
-            return FIMO_STRINGIFY(FIMO_ETIME);
-        case FIMO_ETIMEDOUT:
-            return FIMO_STRINGIFY(FIMO_ETIMEDOUT);
-        case FIMO_ETOOMANYREFS:
-            return FIMO_STRINGIFY(FIMO_ETOOMANYREFS);
-        case FIMO_ETXTBSY:
-            return FIMO_STRINGIFY(FIMO_ETXTBSY);
-        case FIMO_EUCLEAN:
-            return FIMO_STRINGIFY(FIMO_EUCLEAN);
-        case FIMO_EUNATCH:
-            return FIMO_STRINGIFY(FIMO_EUNATCH);
-        case FIMO_EUSERS:
-            return FIMO_STRINGIFY(FIMO_EUSERS);
-        case FIMO_EWOULDBLOCK:
-            return FIMO_STRINGIFY(FIMO_EWOULDBLOCK);
-        case FIMO_EXDEV:
-            return FIMO_STRINGIFY(FIMO_EXDEV);
-        case FIMO_EXFULL:
-            return FIMO_STRINGIFY(FIMO_EXFULL);
-        case FIMO_EUNKNOWN:
-            return FIMO_STRINGIFY(FIMO_EUNKNOWN);
+        case FIMO_ERROR_CODE_OK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_OK);
+        case FIMO_ERROR_CODE_2BIG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_2BIG);
+        case FIMO_ERROR_CODE_ACCES:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ACCES);
+        case FIMO_ERROR_CODE_ADDRINUSE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ADDRINUSE);
+        case FIMO_ERROR_CODE_ADDRNOTAVAIL:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ADDRNOTAVAIL);
+        case FIMO_ERROR_CODE_AFNOSUPPORT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_AFNOSUPPORT);
+        case FIMO_ERROR_CODE_AGAIN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_AGAIN);
+        case FIMO_ERROR_CODE_ALREADY:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ALREADY);
+        case FIMO_ERROR_CODE_BADE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BADE);
+        case FIMO_ERROR_CODE_BADF:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BADF);
+        case FIMO_ERROR_CODE_BADFD:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BADFD);
+        case FIMO_ERROR_CODE_BADMSG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BADMSG);
+        case FIMO_ERROR_CODE_BADR:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BADR);
+        case FIMO_ERROR_CODE_BADRQC:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BADRQC);
+        case FIMO_ERROR_CODE_BADSLT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BADSLT);
+        case FIMO_ERROR_CODE_BUSY:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_BUSY);
+        case FIMO_ERROR_CODE_CANCELED:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_CANCELED);
+        case FIMO_ERROR_CODE_CHILD:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_CHILD);
+        case FIMO_ERROR_CODE_CHRNG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_CHRNG);
+        case FIMO_ERROR_CODE_COMM:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_COMM);
+        case FIMO_ERROR_CODE_CONNABORTED:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_CONNABORTED);
+        case FIMO_ERROR_CODE_CONNREFUSED:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_CONNREFUSED);
+        case FIMO_ERROR_CODE_CONNRESET:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_CONNRESET);
+        case FIMO_ERROR_CODE_DEADLK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_DEADLK);
+        case FIMO_ERROR_CODE_DEADLOCK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_DEADLOCK);
+        case FIMO_ERROR_CODE_DESTADDRREQ:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_DESTADDRREQ);
+        case FIMO_ERROR_CODE_DOM:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_DOM);
+        case FIMO_ERROR_CODE_DQUOT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_DQUOT);
+        case FIMO_ERROR_CODE_EXIST:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_EXIST);
+        case FIMO_ERROR_CODE_FAULT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_FAULT);
+        case FIMO_ERROR_CODE_FBIG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_FBIG);
+        case FIMO_ERROR_CODE_HOSTDOWN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_HOSTDOWN);
+        case FIMO_ERROR_CODE_HOSTUNREACH:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_HOSTUNREACH);
+        case FIMO_ERROR_CODE_HWPOISON:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_HWPOISON);
+        case FIMO_ERROR_CODE_IDRM:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_IDRM);
+        case FIMO_ERROR_CODE_ILSEQ:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ILSEQ);
+        case FIMO_ERROR_CODE_INPROGRESS:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_INPROGRESS);
+        case FIMO_ERROR_CODE_INTR:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_INTR);
+        case FIMO_ERROR_CODE_INVAL:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_INVAL);
+        case FIMO_ERROR_CODE_IO:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_IO);
+        case FIMO_ERROR_CODE_ISCONN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ISCONN);
+        case FIMO_ERROR_CODE_ISDIR:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ISDIR);
+        case FIMO_ERROR_CODE_ISNAM:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ISNAM);
+        case FIMO_ERROR_CODE_KEYEXPIRED:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_KEYEXPIRED);
+        case FIMO_ERROR_CODE_KEYREJECTED:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_KEYREJECTED);
+        case FIMO_ERROR_CODE_KEYREVOKED:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_KEYREVOKED);
+        case FIMO_ERROR_CODE_L2HLT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_L2HLT);
+        case FIMO_ERROR_CODE_L2NSYNC:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_L2NSYNC);
+        case FIMO_ERROR_CODE_L3HLT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_L3HLT);
+        case FIMO_ERROR_CODE_L3RST:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_L3RST);
+        case FIMO_ERROR_CODE_LIBACC:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_LIBACC);
+        case FIMO_ERROR_CODE_LIBBAD:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_LIBBAD);
+        case FIMO_ERROR_CODE_LIBMAX:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_LIBMAX);
+        case FIMO_ERROR_CODE_LIBSCN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_LIBSCN);
+        case FIMO_ERROR_CODE_LIBEXEC:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_LIBEXEC);
+        case FIMO_ERROR_CODE_LNRNG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_LNRNG);
+        case FIMO_ERROR_CODE_LOOP:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_LOOP);
+        case FIMO_ERROR_CODE_MEDIUMTYPE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_MEDIUMTYPE);
+        case FIMO_ERROR_CODE_MFILE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_MFILE);
+        case FIMO_ERROR_CODE_MLINK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_MLINK);
+        case FIMO_ERROR_CODE_MSGSIZE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_MSGSIZE);
+        case FIMO_ERROR_CODE_MULTIHOP:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_MULTIHOP);
+        case FIMO_ERROR_CODE_NAMETOOLONG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NAMETOOLONG);
+        case FIMO_ERROR_CODE_NETDOWN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NETDOWN);
+        case FIMO_ERROR_CODE_NETRESET:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NETRESET);
+        case FIMO_ERROR_CODE_NETUNREACH:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NETUNREACH);
+        case FIMO_ERROR_CODE_NFILE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NFILE);
+        case FIMO_ERROR_CODE_NOANO:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOANO);
+        case FIMO_ERROR_CODE_NOBUFS:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOBUFS);
+        case FIMO_ERROR_CODE_NODATA:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NODATA);
+        case FIMO_ERROR_CODE_NODEV:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NODEV);
+        case FIMO_ERROR_CODE_NOENT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOENT);
+        case FIMO_ERROR_CODE_NOEXEC:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOEXEC);
+        case FIMO_ERROR_CODE_NOKEY:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOKEY);
+        case FIMO_ERROR_CODE_NOLCK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOLCK);
+        case FIMO_ERROR_CODE_NOLINK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOLINK);
+        case FIMO_ERROR_CODE_NOMEDIUM:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOMEDIUM);
+        case FIMO_ERROR_CODE_NOMEM:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOMEM);
+        case FIMO_ERROR_CODE_NOMSG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOMSG);
+        case FIMO_ERROR_CODE_NONET:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NONET);
+        case FIMO_ERROR_CODE_NOPKG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOPKG);
+        case FIMO_ERROR_CODE_NOPROTOOPT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOPROTOOPT);
+        case FIMO_ERROR_CODE_NOSPC:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOSPC);
+        case FIMO_ERROR_CODE_NOSR:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOSR);
+        case FIMO_ERROR_CODE_NOSTR:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOSTR);
+        case FIMO_ERROR_CODE_NOSYS:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOSYS);
+        case FIMO_ERROR_CODE_NOTBLK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTBLK);
+        case FIMO_ERROR_CODE_NOTCONN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTCONN);
+        case FIMO_ERROR_CODE_NOTDIR:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTDIR);
+        case FIMO_ERROR_CODE_NOTEMPTY:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTEMPTY);
+        case FIMO_ERROR_CODE_NOTRECOVERABLE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTRECOVERABLE);
+        case FIMO_ERROR_CODE_NOTSOCK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTSOCK);
+        case FIMO_ERROR_CODE_NOTSUP:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTSUP);
+        case FIMO_ERROR_CODE_NOTTY:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTTY);
+        case FIMO_ERROR_CODE_NOTUNIQ:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NOTUNIQ);
+        case FIMO_ERROR_CODE_NXIO:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_NXIO);
+        case FIMO_ERROR_CODE_OPNOTSUPP:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_OPNOTSUPP);
+        case FIMO_ERROR_CODE_OVERFLOW:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_OVERFLOW);
+        case FIMO_ERROR_CODE_OWNERDEAD:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_OWNERDEAD);
+        case FIMO_ERROR_CODE_PERM:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_PERM);
+        case FIMO_ERROR_CODE_PFNOSUPPORT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_PFNOSUPPORT);
+        case FIMO_ERROR_CODE_PIPE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_PIPE);
+        case FIMO_ERROR_CODE_PROTO:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_PROTO);
+        case FIMO_ERROR_CODE_PROTONOSUPPORT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_PROTONOSUPPORT);
+        case FIMO_ERROR_CODE_PROTOTYPE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_PROTOTYPE);
+        case FIMO_ERROR_CODE_RANGE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_RANGE);
+        case FIMO_ERROR_CODE_REMCHG:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_REMCHG);
+        case FIMO_ERROR_CODE_REMOTE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_REMOTE);
+        case FIMO_ERROR_CODE_REMOTEIO:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_REMOTEIO);
+        case FIMO_ERROR_CODE_RESTART:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_RESTART);
+        case FIMO_ERROR_CODE_RFKILL:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_RFKILL);
+        case FIMO_ERROR_CODE_ROFS:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_ROFS);
+        case FIMO_ERROR_CODE_SHUTDOWN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_SHUTDOWN);
+        case FIMO_ERROR_CODE_SPIPE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_SPIPE);
+        case FIMO_ERROR_CODE_SOCKTNOSUPPORT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_SOCKTNOSUPPORT);
+        case FIMO_ERROR_CODE_SRCH:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_SRCH);
+        case FIMO_ERROR_CODE_STALE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_STALE);
+        case FIMO_ERROR_CODE_STRPIPE:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_STRPIPE);
+        case FIMO_ERROR_CODE_TIME:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_TIME);
+        case FIMO_ERROR_CODE_TIMEDOUT:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_TIMEDOUT);
+        case FIMO_ERROR_CODE_TOOMANYREFS:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_TOOMANYREFS);
+        case FIMO_ERROR_CODE_TXTBSY:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_TXTBSY);
+        case FIMO_ERROR_CODE_UCLEAN:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_UCLEAN);
+        case FIMO_ERROR_CODE_UNATCH:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_UNATCH);
+        case FIMO_ERROR_CODE_USERS:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_USERS);
+        case FIMO_ERROR_CODE_WOULDBLOCK:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_WOULDBLOCK);
+        case FIMO_ERROR_CODE_XDEV:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_XDEV);
+        case FIMO_ERROR_CODE_XFULL:
+            return FIMO_STRINGIFY(FIMO_ERROR_CODE_XFULL);
     }
 
-    if (err) {
-        *err = FIMO_EINVAL;
-    }
-    return "Unknown error number";
+    return "FIMO_ERROR_CODE_UNKNOWN";
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-const char *fimo_strerrordesc(const FimoError errnum, FimoError *err) {
-    if (err) {
-        *err = FIMO_EOK;
-    }
-
+const char *fimo_error_code_description(const FimoErrorCode errnum) {
     switch (errnum) {
-        case FIMO_EOK:
-            return "Operation completed successfully";
-        case FIMO_E2BIG:
-            return "Argument list too long";
-        case FIMO_EACCES:
-            return "Permission denied";
-        case FIMO_EADDRINUSE:
-            return "Address already in use";
-        case FIMO_EADDRNOTAVAIL:
-            return "Address not available";
-        case FIMO_EAFNOSUPPORT:
-            return "Address family not supported";
-        case FIMO_EAGAIN:
-            return "Resource temporarily unavailable";
-        case FIMO_EALREADY:
-            return "Connection already in progress";
-        case FIMO_EBADE:
-            return "Invalid exchange";
-        case FIMO_EBADF:
-            return "Bad file descriptor";
-        case FIMO_EBADFD:
-            return "File descriptor in bad state";
-        case FIMO_EBADMSG:
-            return "Bad message";
-        case FIMO_EBADR:
-            return "Invalid request descriptor";
-        case FIMO_EBADRQC:
-            return "Invalid request code";
-        case FIMO_EBADSLT:
-            return "Invalid slot";
-        case FIMO_EBUSY:
-            return "Device or resource busy";
-        case FIMO_ECANCELED:
-            return "Operation canceled";
-        case FIMO_ECHILD:
-            return "No child processes";
-        case FIMO_ECHRNG:
-            return "Channel number out of range";
-        case FIMO_ECOMM:
-            return "Communication error on send";
-        case FIMO_ECONNABORTED:
-            return "Connection aborted";
-        case FIMO_ECONNREFUSED:
-            return "Connection refused";
-        case FIMO_ECONNRESET:
-            return "Connection reset";
+        case FIMO_ERROR_CODE_OK:
+            return "operation completed successfully";
+        case FIMO_ERROR_CODE_2BIG:
+            return "argument list too long";
+        case FIMO_ERROR_CODE_ACCES:
+            return "permission denied";
+        case FIMO_ERROR_CODE_ADDRINUSE:
+            return "address already in use";
+        case FIMO_ERROR_CODE_ADDRNOTAVAIL:
+            return "address not available";
+        case FIMO_ERROR_CODE_AFNOSUPPORT:
+            return "address family not supported";
+        case FIMO_ERROR_CODE_AGAIN:
+            return "resource temporarily unavailable";
+        case FIMO_ERROR_CODE_ALREADY:
+            return "connection already in progress";
+        case FIMO_ERROR_CODE_BADE:
+            return "invalid exchange";
+        case FIMO_ERROR_CODE_BADF:
+            return "bad file descriptor";
+        case FIMO_ERROR_CODE_BADFD:
+            return "file descriptor in bad state";
+        case FIMO_ERROR_CODE_BADMSG:
+            return "bad message";
+        case FIMO_ERROR_CODE_BADR:
+            return "invalid request descriptor";
+        case FIMO_ERROR_CODE_BADRQC:
+            return "invalid request code";
+        case FIMO_ERROR_CODE_BADSLT:
+            return "invalid slot";
+        case FIMO_ERROR_CODE_BUSY:
+            return "device or resource busy";
+        case FIMO_ERROR_CODE_CANCELED:
+            return "operation canceled";
+        case FIMO_ERROR_CODE_CHILD:
+            return "no child processes";
+        case FIMO_ERROR_CODE_CHRNG:
+            return "channel number out of range";
+        case FIMO_ERROR_CODE_COMM:
+            return "communication error on send";
+        case FIMO_ERROR_CODE_CONNABORTED:
+            return "connection aborted";
+        case FIMO_ERROR_CODE_CONNREFUSED:
+            return "connection refused";
+        case FIMO_ERROR_CODE_CONNRESET:
+            return "connection reset";
 #if defined(EDEADLK) && defined(EDEADLOCK) && EDEADLK == EDEADLOCK
-        case FIMO_EDEADLK:
-        case FIMO_EDEADLOCK:
-            return "Resource deadlock avoided";
+        case FIMO_ERROR_CODE_DEADLK:
+        case FIMO_ERROR_CODE_DEADLOCK:
+            return "resource deadlock avoided";
 #else
-        case FIMO_EDEADLK:
-            return "Resource deadlock avoided";
-        case FIMO_EDEADLOCK:
-            return "File locking deadlock error";
+        case FIMO_ERROR_CODE_DEADLK:
+            return "resource deadlock avoided";
+        case FIMO_ERROR_CODE_DEADLOCK:
+            return "file locking deadlock error";
 #endif // defined(EDEADLK) && defined(EDEADLOCK) && EDEADLK == EDEADLOCK
-        case FIMO_EDESTADDRREQ:
-            return "Destination address required";
-        case FIMO_EDOM:
-            return "Mathematics argument out of domain of function";
-        case FIMO_EDQUOT:
-            return "Disk quota exceeded";
-        case FIMO_EEXIST:
-            return "File exists";
-        case FIMO_EFAULT:
-            return "Bad address";
-        case FIMO_EFBIG:
-            return "File too large";
-        case FIMO_EHOSTDOWN:
-            return "Host is down";
-        case FIMO_EHOSTUNREACH:
-            return "Host is unreachable";
-        case FIMO_EHWPOISON:
-            return "Memory page has hardware error";
-        case FIMO_EIDRM:
-            return "Identifier removed";
-        case FIMO_EILSEQ:
-            return "Invalid or incomplete multibyte or wide character";
-        case FIMO_EINPROGRESS:
-            return "Operation in progress";
-        case FIMO_EINTR:
-            return "Interrupted function call";
-        case FIMO_EINVAL:
-            return "Invalid argument";
-        case FIMO_EIO:
-            return "Input/output error";
-        case FIMO_EISCONN:
-            return "Socket is connected";
-        case FIMO_EISDIR:
-            return "Is a directory";
-        case FIMO_EISNAM:
-            return "Is a named type file";
-        case FIMO_EKEYEXPIRED:
-            return "Key has expired";
-        case FIMO_EKEYREJECTED:
-            return "Key was rejected by service";
-        case FIMO_EKEYREVOKED:
-            return "Key has been revoked";
-        case FIMO_EL2HLT:
-            return "Level 2 halted";
-        case FIMO_EL2NSYNC:
-            return "Level 2 not synchronized";
-        case FIMO_EL3HLT:
-            return "Level 3 halted";
-        case FIMO_EL3RST:
-            return "Level 3 reset";
-        case FIMO_ELIBACC:
-            return "Cannot access a needed shared library";
-        case FIMO_ELIBBAD:
-            return "Accessing a corrupted shared library";
-        case FIMO_ELIBMAX:
-            return "Attempting to link in too many shared libraries";
-        case FIMO_ELIBSCN:
+        case FIMO_ERROR_CODE_DESTADDRREQ:
+            return "destination address required";
+        case FIMO_ERROR_CODE_DOM:
+            return "mathematics argument out of domain of function";
+        case FIMO_ERROR_CODE_DQUOT:
+            return "disk quota exceeded";
+        case FIMO_ERROR_CODE_EXIST:
+            return "file exists";
+        case FIMO_ERROR_CODE_FAULT:
+            return "bad address";
+        case FIMO_ERROR_CODE_FBIG:
+            return "file too large";
+        case FIMO_ERROR_CODE_HOSTDOWN:
+            return "host is down";
+        case FIMO_ERROR_CODE_HOSTUNREACH:
+            return "host is unreachable";
+        case FIMO_ERROR_CODE_HWPOISON:
+            return "memory page has hardware error";
+        case FIMO_ERROR_CODE_IDRM:
+            return "identifier removed";
+        case FIMO_ERROR_CODE_ILSEQ:
+            return "invalid or incomplete multibyte or wide character";
+        case FIMO_ERROR_CODE_INPROGRESS:
+            return "operation in progress";
+        case FIMO_ERROR_CODE_INTR:
+            return "interrupted function call";
+        case FIMO_ERROR_CODE_INVAL:
+            return "invalid argument";
+        case FIMO_ERROR_CODE_IO:
+            return "input/output error";
+        case FIMO_ERROR_CODE_ISCONN:
+            return "socket is connected";
+        case FIMO_ERROR_CODE_ISDIR:
+            return "is a directory";
+        case FIMO_ERROR_CODE_ISNAM:
+            return "is a named type file";
+        case FIMO_ERROR_CODE_KEYEXPIRED:
+            return "key has expired";
+        case FIMO_ERROR_CODE_KEYREJECTED:
+            return "key was rejected by service";
+        case FIMO_ERROR_CODE_KEYREVOKED:
+            return "key has been revoked";
+        case FIMO_ERROR_CODE_L2HLT:
+            return "level 2 halted";
+        case FIMO_ERROR_CODE_L2NSYNC:
+            return "level 2 not synchronized";
+        case FIMO_ERROR_CODE_L3HLT:
+            return "level 3 halted";
+        case FIMO_ERROR_CODE_L3RST:
+            return "level 3 reset";
+        case FIMO_ERROR_CODE_LIBACC:
+            return "cannot access a needed shared library";
+        case FIMO_ERROR_CODE_LIBBAD:
+            return "accessing a corrupted shared library";
+        case FIMO_ERROR_CODE_LIBMAX:
+            return "attempting to link in too many shared libraries";
+        case FIMO_ERROR_CODE_LIBSCN:
             return ".lib section in a.out corrupted";
-        case FIMO_ELIBEXEC:
-            return "Cannot exec a shared library directly";
-        case FIMO_ELNRNG:
-            return "Link number out of range";
-        case FIMO_ELOOP:
-            return "Too many levels of symbolic links";
-        case FIMO_EMEDIUMTYPE:
-            return "Wrong medium type";
-        case FIMO_EMFILE:
-            return "Too many open files";
-        case FIMO_EMLINK:
-            return "Too many links";
-        case FIMO_EMSGSIZE:
-            return "Message too long";
-        case FIMO_EMULTIHOP:
-            return "Multihop attempted";
-        case FIMO_ENAMETOOLONG:
-            return "Filename too long";
-        case FIMO_ENETDOWN:
-            return "Network is down";
-        case FIMO_ENETRESET:
-            return "Connection aborted by network";
-        case FIMO_ENETUNREACH:
-            return "Network unreachable";
-        case FIMO_ENFILE:
-            return "Too many open files in system";
-        case FIMO_ENOANO:
-            return "No anode";
-        case FIMO_ENOBUFS:
-            return "No buffer space available";
-        case FIMO_ENODATA:
-            return "The named attribute does not exist, or the process has no access to this attribute";
-        case FIMO_ENODEV:
-            return "No such device";
-        case FIMO_ENOENT:
-            return "No such file or directory";
-        case FIMO_ENOEXEC:
-            return "Exec format error";
-        case FIMO_ENOKEY:
-            return "Required key not available";
-        case FIMO_ENOLCK:
-            return "No locks available";
-        case FIMO_ENOLINK:
-            return "Link has been severed";
-        case FIMO_ENOMEDIUM:
-            return "No medium found";
-        case FIMO_ENOMEM:
-            return "Not enough space/cannot allocate memory";
-        case FIMO_ENOMSG:
-            return "No message of the desired type";
-        case FIMO_ENONET:
-            return "Machine is not on the network";
-        case FIMO_ENOPKG:
-            return "Package not installed";
-        case FIMO_ENOPROTOOPT:
-            return "Protocol not available";
-        case FIMO_ENOSPC:
-            return "No space left on device";
-        case FIMO_ENOSR:
-            return "No STREAM resources";
-        case FIMO_ENOSTR:
-            return "Not a STREAM";
-        case FIMO_ENOSYS:
-            return "Function not implemented";
-        case FIMO_ENOTBLK:
-            return "Block device required";
-        case FIMO_ENOTCONN:
-            return "The socket is not connected";
-        case FIMO_ENOTDIR:
-            return "Not a directory";
-        case FIMO_ENOTEMPTY:
-            return "Directory not empty";
-        case FIMO_ENOTRECOVERABLE:
-            return "State not recoverable";
-        case FIMO_ENOTSOCK:
-            return "Not a socket";
-        case FIMO_ENOTSUP:
-            return "Operation not supported";
-        case FIMO_ENOTTY:
-            return "Inappropriate I/O control operation";
-        case FIMO_ENOTUNIQ:
-            return "Name not unique on network";
-        case FIMO_ENXIO:
-            return "No such device or address";
-        case FIMO_EOPNOTSUPP:
-            return "Operation not supported on socket";
-        case FIMO_EOVERFLOW:
-            return "Value too large to be stored in data type";
-        case FIMO_EOWNERDEAD:
-            return "Owner died";
-        case FIMO_EPERM:
-            return "Operation not permitted";
-        case FIMO_EPFNOSUPPORT:
-            return "Protocol family not supported";
-        case FIMO_EPIPE:
-            return "Broken pipe";
-        case FIMO_EPROTO:
-            return "Protocol error";
-        case FIMO_EPROTONOSUPPORT:
-            return "Protocol not supported";
-        case FIMO_EPROTOTYPE:
-            return "Protocol wrong type for socket";
-        case FIMO_ERANGE:
-            return "Result too large";
-        case FIMO_EREMCHG:
-            return "Remote address changed";
-        case FIMO_EREMOTE:
-            return "Object is remote";
-        case FIMO_EREMOTEIO:
-            return "Remote I/O error";
-        case FIMO_ERESTART:
-            return "Interrupted system call should be restarted";
-        case FIMO_ERFKILL:
-            return "Operation not possible due to RF-kill";
-        case FIMO_EROFS:
-            return "Read-only filesystem";
-        case FIMO_ESHUTDOWN:
-            return "Cannot send after transport endpoint shutdown";
-        case FIMO_ESPIPE:
-            return "Invalid seek";
-        case FIMO_ESOCKTNOSUPPORT:
-            return "Socket type not supported";
-        case FIMO_ESRCH:
-            return "No such process";
-        case FIMO_ESTALE:
-            return "Stale file handle";
-        case FIMO_ESTRPIPE:
-            return "Streams pipe error";
-        case FIMO_ETIME:
-            return "Timer expired";
-        case FIMO_ETIMEDOUT:
-            return "Connection timed out";
-        case FIMO_ETOOMANYREFS:
-            return "Too many references: cannot splice";
-        case FIMO_ETXTBSY:
-            return "Text file busy";
-        case FIMO_EUCLEAN:
-            return "Structure needs cleaning";
-        case FIMO_EUNATCH:
-            return "Protocol driver not attached";
-        case FIMO_EUSERS:
-            return "Too many users";
-        case FIMO_EWOULDBLOCK:
-            return "Operation would block";
-        case FIMO_EXDEV:
-            return "Invalid cross-device link";
-        case FIMO_EXFULL:
-            return "Exchange full";
-        case FIMO_EUNKNOWN:
-            return "Unknown error";
+        case FIMO_ERROR_CODE_LIBEXEC:
+            return "cannot exec a shared library directly";
+        case FIMO_ERROR_CODE_LNRNG:
+            return "link number out of range";
+        case FIMO_ERROR_CODE_LOOP:
+            return "too many levels of symbolic links";
+        case FIMO_ERROR_CODE_MEDIUMTYPE:
+            return "wrong medium type";
+        case FIMO_ERROR_CODE_MFILE:
+            return "too many open files";
+        case FIMO_ERROR_CODE_MLINK:
+            return "too many links";
+        case FIMO_ERROR_CODE_MSGSIZE:
+            return "message too long";
+        case FIMO_ERROR_CODE_MULTIHOP:
+            return "multihop attempted";
+        case FIMO_ERROR_CODE_NAMETOOLONG:
+            return "filename too long";
+        case FIMO_ERROR_CODE_NETDOWN:
+            return "network is down";
+        case FIMO_ERROR_CODE_NETRESET:
+            return "connection aborted by network";
+        case FIMO_ERROR_CODE_NETUNREACH:
+            return "network unreachable";
+        case FIMO_ERROR_CODE_NFILE:
+            return "too many open files in system";
+        case FIMO_ERROR_CODE_NOANO:
+            return "no anode";
+        case FIMO_ERROR_CODE_NOBUFS:
+            return "no buffer space available";
+        case FIMO_ERROR_CODE_NODATA:
+            return "the named attribute does not exist, or the process has no access to this attribute";
+        case FIMO_ERROR_CODE_NODEV:
+            return "no such device";
+        case FIMO_ERROR_CODE_NOENT:
+            return "no such file or directory";
+        case FIMO_ERROR_CODE_NOEXEC:
+            return "exec format error";
+        case FIMO_ERROR_CODE_NOKEY:
+            return "required key not available";
+        case FIMO_ERROR_CODE_NOLCK:
+            return "no locks available";
+        case FIMO_ERROR_CODE_NOLINK:
+            return "link has been severed";
+        case FIMO_ERROR_CODE_NOMEDIUM:
+            return "no medium found";
+        case FIMO_ERROR_CODE_NOMEM:
+            return "not enough space/cannot allocate memory";
+        case FIMO_ERROR_CODE_NOMSG:
+            return "no message of the desired type";
+        case FIMO_ERROR_CODE_NONET:
+            return "machine is not on the network";
+        case FIMO_ERROR_CODE_NOPKG:
+            return "package not installed";
+        case FIMO_ERROR_CODE_NOPROTOOPT:
+            return "protocol not available";
+        case FIMO_ERROR_CODE_NOSPC:
+            return "no space left on device";
+        case FIMO_ERROR_CODE_NOSR:
+            return "no STREAM resources";
+        case FIMO_ERROR_CODE_NOSTR:
+            return "not a STREAM";
+        case FIMO_ERROR_CODE_NOSYS:
+            return "function not implemented";
+        case FIMO_ERROR_CODE_NOTBLK:
+            return "block device required";
+        case FIMO_ERROR_CODE_NOTCONN:
+            return "the socket is not connected";
+        case FIMO_ERROR_CODE_NOTDIR:
+            return "not a directory";
+        case FIMO_ERROR_CODE_NOTEMPTY:
+            return "directory not empty";
+        case FIMO_ERROR_CODE_NOTRECOVERABLE:
+            return "state not recoverable";
+        case FIMO_ERROR_CODE_NOTSOCK:
+            return "not a socket";
+        case FIMO_ERROR_CODE_NOTSUP:
+            return "operation not supported";
+        case FIMO_ERROR_CODE_NOTTY:
+            return "inappropriate I/O control operation";
+        case FIMO_ERROR_CODE_NOTUNIQ:
+            return "name not unique on network";
+        case FIMO_ERROR_CODE_NXIO:
+            return "no such device or address";
+        case FIMO_ERROR_CODE_OPNOTSUPP:
+            return "operation not supported on socket";
+        case FIMO_ERROR_CODE_OVERFLOW:
+            return "value too large to be stored in data type";
+        case FIMO_ERROR_CODE_OWNERDEAD:
+            return "owner died";
+        case FIMO_ERROR_CODE_PERM:
+            return "operation not permitted";
+        case FIMO_ERROR_CODE_PFNOSUPPORT:
+            return "protocol family not supported";
+        case FIMO_ERROR_CODE_PIPE:
+            return "broken pipe";
+        case FIMO_ERROR_CODE_PROTO:
+            return "protocol error";
+        case FIMO_ERROR_CODE_PROTONOSUPPORT:
+            return "protocol not supported";
+        case FIMO_ERROR_CODE_PROTOTYPE:
+            return "protocol wrong type for socket";
+        case FIMO_ERROR_CODE_RANGE:
+            return "result too large";
+        case FIMO_ERROR_CODE_REMCHG:
+            return "remote address changed";
+        case FIMO_ERROR_CODE_REMOTE:
+            return "object is remote";
+        case FIMO_ERROR_CODE_REMOTEIO:
+            return "remote I/O error";
+        case FIMO_ERROR_CODE_RESTART:
+            return "interrupted system call should be restarted";
+        case FIMO_ERROR_CODE_RFKILL:
+            return "operation not possible due to RF-kill";
+        case FIMO_ERROR_CODE_ROFS:
+            return "read-only filesystem";
+        case FIMO_ERROR_CODE_SHUTDOWN:
+            return "cannot send after transport endpoint shutdown";
+        case FIMO_ERROR_CODE_SPIPE:
+            return "invalid seek";
+        case FIMO_ERROR_CODE_SOCKTNOSUPPORT:
+            return "socket type not supported";
+        case FIMO_ERROR_CODE_SRCH:
+            return "no such process";
+        case FIMO_ERROR_CODE_STALE:
+            return "stale file handle";
+        case FIMO_ERROR_CODE_STRPIPE:
+            return "streams pipe error";
+        case FIMO_ERROR_CODE_TIME:
+            return "timer expired";
+        case FIMO_ERROR_CODE_TIMEDOUT:
+            return "connection timed out";
+        case FIMO_ERROR_CODE_TOOMANYREFS:
+            return "too many references: cannot splice";
+        case FIMO_ERROR_CODE_TXTBSY:
+            return "text file busy";
+        case FIMO_ERROR_CODE_UCLEAN:
+            return "structure needs cleaning";
+        case FIMO_ERROR_CODE_UNATCH:
+            return "protocol driver not attached";
+        case FIMO_ERROR_CODE_USERS:
+            return "too many users";
+        case FIMO_ERROR_CODE_WOULDBLOCK:
+            return "operation would block";
+        case FIMO_ERROR_CODE_XDEV:
+            return "invalid cross-device link";
+        case FIMO_ERROR_CODE_XFULL:
+            return "exchange full";
     }
 
-    if (err) {
-        *err = FIMO_EINVAL;
-    }
-    return "Unknown error number";
+    return "unknown error code";
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_error_from_errno(const int errnum) {
+FimoErrorCode fimo_error_code_from_errno(const int errnum) {
     switch (errnum) {
         case 0:
-            return FIMO_EOK;
+            return FIMO_ERROR_CODE_OK;
 
 #ifdef E2BIG
         case E2BIG:
-            return FIMO_E2BIG;
+            return FIMO_ERROR_CODE_2BIG;
 #endif // E2BIG
 
 #ifdef EACCES
         case EACCES:
-            return FIMO_EACCES;
+            return FIMO_ERROR_CODE_ACCES;
 #endif // EACCES
 
 #ifdef EADDRINUSE
         case EADDRINUSE:
-            return FIMO_EADDRINUSE;
+            return FIMO_ERROR_CODE_ADDRINUSE;
 #endif // EADDRINUSE
 
 #ifdef EADDRNOTAVAIL
         case EADDRNOTAVAIL:
-            return FIMO_EADDRNOTAVAIL;
+            return FIMO_ERROR_CODE_ADDRNOTAVAIL;
 #endif // EADDRNOTAVAIL
 
 #ifdef EAFNOSUPPORT
         case EAFNOSUPPORT:
-            return FIMO_EAFNOSUPPORT;
+            return FIMO_ERROR_CODE_AFNOSUPPORT;
 #endif // EAFNOSUPPORT
 
 // EAGAIN and EWOULDBLOCK are allowed to be the same value
 #if defined(EAGAIN) && defined(EWOULDBLOCK) && EAGAIN == EWOULDBLOCK
         case EAGAIN:
-            return FIMO_EAGAIN;
+            return FIMO_ERROR_CODE_AGAIN;
 #else
 #ifdef EAGAIN
         case EAGAIN:
-            return FIMO_EAGAIN;
+            return FIMO_ERROR_CODE_AGAIN;
 #endif // EAGAIN
 
 #ifdef EWOULDBLOCK
         case EWOULDBLOCK:
-            return FIMO_EWOULDBLOCK;
+            return FIMO_ERROR_CODE_WOULDBLOCK;
 #endif // EWOULDBLOCK
 #endif // defined(EAGAIN) && defined(EWOULDBLOCK) && EAGAIN == EWOULDBLOCK
 
 #ifdef EALREADY
         case EALREADY:
-            return FIMO_EALREADY;
+            return FIMO_ERROR_CODE_ALREADY;
 #endif // EALREADY
 
 #ifdef EBADE
         case EBADE:
-            return FIMO_EBADE;
+            return FIMO_ERROR_CODE_BADE;
 #endif // EBADE
 
 #ifdef EBADF
         case EBADF:
-            return FIMO_EBADF;
+            return FIMO_ERROR_CODE_BADF;
 #endif // EBADF
 
 #ifdef EBADFD
         case EBADFD:
-            return FIMO_EBADFD;
+            return FIMO_ERROR_CODE_BADFD;
 #endif // EBADFD
 
 #ifdef EBADMSG
         case EBADMSG:
-            return FIMO_EBADMSG;
+            return FIMO_ERROR_CODE_BADMSG;
 #endif // EBADMSG
 
 #ifdef EBADR
         case EBADR:
-            return FIMO_EBADR;
+            return FIMO_ERROR_CODE_BADR;
 #endif // EBADR
 
 #ifdef EBADRQC
         case EBADRQC:
-            return FIMO_EBADRQC;
+            return FIMO_ERROR_CODE_BADRQC;
 #endif // EBADRQC
 
 #ifdef EBADSLT
         case EBADSLT:
-            return FIMO_EBADSLT;
+            return FIMO_ERROR_CODE_BADSLT;
 #endif // EBADSLT
 
 #ifdef EBUSY
         case EBUSY:
-            return FIMO_EBUSY;
+            return FIMO_ERROR_CODE_BUSY;
 #endif // EBUSY
 
 #ifdef ECANCELED
         case ECANCELED:
-            return FIMO_ECANCELED;
+            return FIMO_ERROR_CODE_CANCELED;
 #endif // ECANCELED
 
 #ifdef ECHILD
         case ECHILD:
-            return FIMO_ECHILD;
+            return FIMO_ERROR_CODE_CHILD;
 #endif // ECHILD
 
 #ifdef ECHRNG
         case ECHRNG:
-            return FIMO_ECHRNG;
+            return FIMO_ERROR_CODE_CHRNG;
 #endif // ECHRNG
 
 #ifdef ECOMM
         case ECOMM:
-            return FIMO_ECOMM;
+            return FIMO_ERROR_CODE_COMM;
 #endif // ECOMM
 
 #ifdef ECONNABORTED
         case ECONNABORTED:
-            return FIMO_ECONNABORTED;
+            return FIMO_ERROR_CODE_CONNABORTED;
 #endif // ECONNABORTED
 
 #ifdef ECONNREFUSED
         case ECONNREFUSED:
-            return FIMO_ECONNREFUSED;
+            return FIMO_ERROR_CODE_CONNREFUSED;
 #endif // ECONNREFUSED
 
 #ifdef ECONNRESET
         case ECONNRESET:
-            return FIMO_ECONNRESET;
+            return FIMO_ERROR_CODE_CONNRESET;
 #endif // ECONNRESET
 
 // EDEADLOCK is usually a synonym for EDEADLK
 #if defined(EDEADLK) && defined(EDEADLOCK) && EDEADLK == EDEADLOCK
         case EDEADLK:
-            return FIMO_EDEADLK;
+            return FIMO_ERROR_CODE_DEADLK;
 #else
 #ifdef EDEADLK
         case EDEADLK:
-            return FIMO_EDEADLK;
+            return FIMO_ERROR_CODE_DEADLK;
 #endif // EDEADLK
 #ifdef EDEADLOCK
         case EDEADLOCK:
-            return FIMO_EDEADLOCK;
+            return FIMO_ERROR_CODE_DEADLOCK;
 #endif // EDEADLOCK
 #endif // defined(EDEADLK) && defined(EDEADLOCK) && EDEADLK == EDEADLOCK
 
 #ifdef EDESTADDRREQ
         case EDESTADDRREQ:
-            return FIMO_EDESTADDRREQ;
+            return FIMO_ERROR_CODE_DESTADDRREQ;
 #endif // EDESTADDRREQ
 
 #ifdef EDOM
         case EDOM:
-            return FIMO_EDOM;
+            return FIMO_ERROR_CODE_DOM;
 #endif // EDOM
 
 #ifdef EDQUOT
         case EDQUOT:
-            return FIMO_EDQUOT;
+            return FIMO_ERROR_CODE_DQUOT;
 #endif // EDQUOT
 
 #ifdef EEXIST
         case EEXIST:
-            return FIMO_EEXIST;
+            return FIMO_ERROR_CODE_EXIST;
 #endif // EEXIST
 
 #ifdef EFAULT
         case EFAULT:
-            return FIMO_EFAULT;
+            return FIMO_ERROR_CODE_FAULT;
 #endif // EFAULT
 
 #ifdef EFBIG
         case EFBIG:
-            return FIMO_EFBIG;
+            return FIMO_ERROR_CODE_FBIG;
 #endif // EFBIG
 
 #ifdef EHOSTDOWN
         case EHOSTDOWN:
-            return FIMO_EHOSTDOWN;
+            return FIMO_ERROR_CODE_HOSTDOWN;
 #endif // EHOSTDOWN
 
 #ifdef EHOSTUNREACH
         case EHOSTUNREACH:
-            return FIMO_EHOSTUNREACH;
+            return FIMO_ERROR_CODE_HOSTUNREACH;
 #endif // EHOSTUNREACH
 
 #ifdef EHWPOISON
         case EHWPOISON:
-            return FIMO_EHWPOISON;
+            return FIMO_ERROR_CODE_HWPOISON;
 #endif // EHWPOISON
 
 #ifdef EIDRM
         case EIDRM:
-            return FIMO_EIDRM;
+            return FIMO_ERROR_CODE_IDRM;
 #endif // EIDRM
 
 #ifdef EILSEQ
         case EILSEQ:
-            return FIMO_EILSEQ;
+            return FIMO_ERROR_CODE_ILSEQ;
 #endif // EILSEQ
 
 #ifdef EINPROGRESS
         case EINPROGRESS:
-            return FIMO_EINPROGRESS;
+            return FIMO_ERROR_CODE_INPROGRESS;
 #endif // EINPROGRESS
 
 #ifdef EINTR
         case EINTR:
-            return FIMO_EINTR;
+            return FIMO_ERROR_CODE_INTR;
 #endif // EINTR
 
 #ifdef EINVAL
         case EINVAL:
-            return FIMO_EINVAL;
+            return FIMO_ERROR_CODE_INVAL;
 #endif // EINVAL
 
 #ifdef EIO
         case EIO:
-            return FIMO_EIO;
+            return FIMO_ERROR_CODE_IO;
 #endif // EIO
 
 #ifdef EISCONN
         case EISCONN:
-            return FIMO_EISCONN;
+            return FIMO_ERROR_CODE_ISCONN;
 #endif // EISCONN
 
 #ifdef EISDIR
         case EISDIR:
-            return FIMO_EISDIR;
+            return FIMO_ERROR_CODE_ISDIR;
 #endif // EISDIR
 
 #ifdef EISNAM
         case EISNAM:
-            return FIMO_EISNAM;
+            return FIMO_ERROR_CODE_ISNAM;
 #endif // EISNAM
 
 #ifdef EKEYEXPIRED
         case EKEYEXPIRED:
-            return FIMO_EKEYEXPIRED;
+            return FIMO_ERROR_CODE_KEYEXPIRED;
 #endif // EKEYEXPIRED
 
 #ifdef EKEYREJECTED
         case EKEYREJECTED:
-            return FIMO_EKEYREJECTED;
+            return FIMO_ERROR_CODE_KEYREJECTED;
 #endif // EKEYREJECTED
 
 #ifdef EKEYREVOKED
         case EKEYREVOKED:
-            return FIMO_EKEYREVOKED;
+            return FIMO_ERROR_CODE_KEYREVOKED;
 #endif // EKEYREVOKED
 
 #ifdef EL2HLT
         case EL2HLT:
-            return FIMO_EL2HLT;
+            return FIMO_ERROR_CODE_L2HLT;
 #endif // EL2HLT
 
 #ifdef EL2NSYNC
         case EL2NSYNC:
-            return FIMO_EL2NSYNC;
+            return FIMO_ERROR_CODE_L2NSYNC;
 #endif // EL2NSYNC
 
 #ifdef EL3HLT
         case EL3HLT:
-            return FIMO_EL3HLT;
+            return FIMO_ERROR_CODE_L3HLT;
 #endif // EL3HLT
 
 #ifdef EL3RST
         case EL3RST:
-            return FIMO_EL3RST;
+            return FIMO_ERROR_CODE_L3RST;
 #endif // EL3RST
 
 #ifdef ELIBACC
         case ELIBACC:
-            return FIMO_ELIBACC;
+            return FIMO_ERROR_CODE_LIBACC;
 #endif // ELIBACC
 
 #ifdef ELIBBAD
         case ELIBBAD:
-            return FIMO_ELIBBAD;
+            return FIMO_ERROR_CODE_LIBBAD;
 #endif // ELIBBAD
 
 #ifdef ELIBMAX
         case ELIBMAX:
-            return FIMO_ELIBMAX;
+            return FIMO_ERROR_CODE_LIBMAX;
 #endif // ELIBMAX
 
 #ifdef ELIBSCN
         case ELIBSCN:
-            return FIMO_ELIBSCN;
+            return FIMO_ERROR_CODE_LIBSCN;
 #endif // ELIBSCN
 
 #ifdef ELIBEXEC
         case ELIBEXEC:
-            return FIMO_ELIBEXEC;
+            return FIMO_ERROR_CODE_LIBEXEC;
 #endif // ELIBEXEC
 
 #ifdef ELNRNG
         case ELNRNG:
-            return FIMO_ELNRNG;
+            return FIMO_ERROR_CODE_LNRNG;
 #endif // ELNRNG
 
 #ifdef ELOOP
         case ELOOP:
-            return FIMO_ELOOP;
+            return FIMO_ERROR_CODE_LOOP;
 #endif // ELOOP
 
 #ifdef EMEDIUMTYPE
         case EMEDIUMTYPE:
-            return FIMO_EMEDIUMTYPE;
+            return FIMO_ERROR_CODE_MEDIUMTYPE;
 #endif // EMEDIUMTYPE
 
 #ifdef EMFILE
         case EMFILE:
-            return FIMO_EMFILE;
+            return FIMO_ERROR_CODE_MFILE;
 #endif // EMFILE
 
 #ifdef EMLINK
         case EMLINK:
-            return FIMO_EMLINK;
+            return FIMO_ERROR_CODE_MLINK;
 #endif // EMLINK
 
 #ifdef EMSGSIZE
         case EMSGSIZE:
-            return FIMO_EMSGSIZE;
+            return FIMO_ERROR_CODE_MSGSIZE;
 #endif // EMSGSIZE
 
 #ifdef EMULTIHOP
         case EMULTIHOP:
-            return FIMO_EMULTIHOP;
+            return FIMO_ERROR_CODE_MULTIHOP;
 #endif // EMULTIHOP
 
 #ifdef ENAMETOOLONG
         case ENAMETOOLONG:
-            return FIMO_ENAMETOOLONG;
+            return FIMO_ERROR_CODE_NAMETOOLONG;
 #endif // ENAMETOOLONG
 
 #ifdef ENETDOWN
         case ENETDOWN:
-            return FIMO_ENETDOWN;
+            return FIMO_ERROR_CODE_NETDOWN;
 #endif // ENETDOWN
 
 #ifdef ENETRESET
         case ENETRESET:
-            return FIMO_ENETRESET;
+            return FIMO_ERROR_CODE_NETRESET;
 #endif // ENETRESET
 
 #ifdef ENETUNREACH
         case ENETUNREACH:
-            return FIMO_ENETUNREACH;
+            return FIMO_ERROR_CODE_NETUNREACH;
 #endif // ENETUNREACH
 
 #ifdef ENFILE
         case ENFILE:
-            return FIMO_ENFILE;
+            return FIMO_ERROR_CODE_NFILE;
 #endif // ENFILE
 
 #ifdef ENOANO
         case ENOANO:
-            return FIMO_ENOANO;
+            return FIMO_ERROR_CODE_NOANO;
 #endif // ENOANO
 
 #ifdef ENOBUFS
         case ENOBUFS:
-            return FIMO_ENOBUFS;
+            return FIMO_ERROR_CODE_NOBUFS;
 #endif // ENOBUFS
 
 #ifdef ENODATA
         case ENODATA:
-            return FIMO_ENODATA;
+            return FIMO_ERROR_CODE_NODATA;
 #endif // ENODATA
 
 #ifdef ENODEV
         case ENODEV:
-            return FIMO_ENODEV;
+            return FIMO_ERROR_CODE_NODEV;
 #endif // ENODEV
 
 #ifdef ENOENT
         case ENOENT:
-            return FIMO_ENOENT;
+            return FIMO_ERROR_CODE_NOENT;
 #endif // ENOENT
 
 #ifdef ENOEXEC
         case ENOEXEC:
-            return FIMO_ENOEXEC;
+            return FIMO_ERROR_CODE_NOEXEC;
 #endif // ENOEXEC
 
 #ifdef ENOKEY
         case ENOKEY:
-            return FIMO_ENOKEY;
+            return FIMO_ERROR_CODE_NOKEY;
 #endif // ENOKEY
 
 #ifdef ENOLCK
         case ENOLCK:
-            return FIMO_ENOLCK;
+            return FIMO_ERROR_CODE_NOLCK;
 #endif // ENOLCK
 
 #ifdef ENOLINK
         case ENOLINK:
-            return FIMO_ENOLINK;
+            return FIMO_ERROR_CODE_NOLINK;
 #endif // ENOLINK
 
 #ifdef ENOMEDIUM
         case ENOMEDIUM:
-            return FIMO_ENOMEDIUM;
+            return FIMO_ERROR_CODE_NOMEDIUM;
 #endif // ENOMEDIUM
 
 #ifdef ENOMEM
         case ENOMEM:
-            return FIMO_ENOMEM;
+            return FIMO_ERROR_CODE_NOMEM;
 #endif // ENOMEM
 
 #ifdef ENOMSG
         case ENOMSG:
-            return FIMO_ENOMSG;
+            return FIMO_ERROR_CODE_NOMSG;
 #endif // ENOMSG
 
 #ifdef ENONET
         case ENONET:
-            return FIMO_ENONET;
+            return FIMO_ERROR_CODE_NONET;
 #endif // ENONET
 
 #ifdef ENOPKG
         case ENOPKG:
-            return FIMO_ENOPKG;
+            return FIMO_ERROR_CODE_NOPKG;
 #endif // ENOPKG
 
 #ifdef ENOPROTOOPT
         case ENOPROTOOPT:
-            return FIMO_ENOPROTOOPT;
+            return FIMO_ERROR_CODE_NOPROTOOPT;
 #endif // ENOPROTOOPT
 
 #ifdef ENOSPC
         case ENOSPC:
-            return FIMO_ENOSPC;
+            return FIMO_ERROR_CODE_NOSPC;
 #endif // ENOSPC
 
 #ifdef ENOSR
         case ENOSR:
-            return FIMO_ENOSR;
+            return FIMO_ERROR_CODE_NOSR;
 #endif // ENOSR
 
 #ifdef ENOSTR
         case ENOSTR:
-            return FIMO_ENOSTR;
+            return FIMO_ERROR_CODE_NOSTR;
 #endif // ENOSTR
 
 #ifdef ENOSYS
         case ENOSYS:
-            return FIMO_ENOSYS;
+            return FIMO_ERROR_CODE_NOSYS;
 #endif // ENOSYS
 
 #ifdef ENOTBLK
         case ENOTBLK:
-            return FIMO_ENOTBLK;
+            return FIMO_ERROR_CODE_NOTBLK;
 #endif // ENOTBLK
 
 #ifdef ENOTCONN
         case ENOTCONN:
-            return FIMO_ENOTCONN;
+            return FIMO_ERROR_CODE_NOTCONN;
 #endif // ENOTCONN
 
 #ifdef ENOTDIR
         case ENOTDIR:
-            return FIMO_ENOTDIR;
+            return FIMO_ERROR_CODE_NOTDIR;
 #endif // ENOTDIR
 
 #ifdef ENOTEMPTY
         case ENOTEMPTY:
-            return FIMO_ENOTEMPTY;
+            return FIMO_ERROR_CODE_NOTEMPTY;
 #endif // ENOTEMPTY
 
 #ifdef ENOTRECOVERABLE
         case ENOTRECOVERABLE:
-            return FIMO_ENOTRECOVERABLE;
+            return FIMO_ERROR_CODE_NOTRECOVERABLE;
 #endif // ENOTRECOVERABLE
 
 #ifdef ENOTSOCK
         case ENOTSOCK:
-            return FIMO_ENOTSOCK;
+            return FIMO_ERROR_CODE_NOTSOCK;
 #endif // ENOTSOCK
 
 // EOPNOTSUPP and ENOTSUP have the same value on linux.
 #if defined(ENOTSUP) && defined(EOPNOTSUPP) && ENOTSUP == EOPNOTSUPP
         case ENOTSUP:
-            return FIMO_ENOTSUP;
+            return FIMO_ERROR_CODE_NOTSUP;
 #else
 #ifdef ENOTSUP
         case ENOTSUP:
-            return FIMO_ENOTSUP;
+            return FIMO_ERROR_CODE_NOTSUP;
 #endif // ENOTSUP
 
 #ifdef EOPNOTSUPP
         case EOPNOTSUPP:
-            return FIMO_EOPNOTSUPP;
+            return FIMO_ERROR_CODE_OPNOTSUPP;
 #endif // EOPNOTSUPP
 #endif // defined(ENOTSUP) && defined(EOPNOTSUPP) && ENOTSUP == EOPNOTSUPP
 
 #ifdef ENOTTY
         case ENOTTY:
-            return FIMO_ENOTTY;
+            return FIMO_ERROR_CODE_NOTTY;
 #endif // ENOTTY
 
 #ifdef ENOTUNIQ
         case ENOTUNIQ:
-            return FIMO_ENOTUNIQ;
+            return FIMO_ERROR_CODE_NOTUNIQ;
 #endif // ENOTUNIQ
 
 #ifdef ENXIO
         case ENXIO:
-            return FIMO_ENXIO;
+            return FIMO_ERROR_CODE_NXIO;
 #endif // ENXIO
 
 #ifdef EOVERFLOW
         case EOVERFLOW:
-            return FIMO_EOVERFLOW;
+            return FIMO_ERROR_CODE_OVERFLOW;
 #endif // EOVERFLOW
 
 #ifdef EOWNERDEAD
         case EOWNERDEAD:
-            return FIMO_EOWNERDEAD;
+            return FIMO_ERROR_CODE_OWNERDEAD;
 #endif // EOWNERDEAD
 
 #ifdef EPERM
         case EPERM:
-            return FIMO_EPERM;
+            return FIMO_ERROR_CODE_PERM;
 #endif // EPERM
 
 #ifdef EPFNOSUPPORT
         case EPFNOSUPPORT:
-            return FIMO_EPFNOSUPPORT;
+            return FIMO_ERROR_CODE_PFNOSUPPORT;
 #endif // EPFNOSUPPORT
 
 #ifdef EPIPE
         case EPIPE:
-            return FIMO_EPIPE;
+            return FIMO_ERROR_CODE_PIPE;
 #endif // EPIPE
 
 #ifdef EPROTO
         case EPROTO:
-            return FIMO_EPROTO;
+            return FIMO_ERROR_CODE_PROTO;
 #endif // EPROTO
 
 #ifdef EPROTONOSUPPORT
         case EPROTONOSUPPORT:
-            return FIMO_EPROTONOSUPPORT;
+            return FIMO_ERROR_CODE_PROTONOSUPPORT;
 #endif // EPROTONOSUPPORT
 
 #ifdef EPROTOTYPE
         case EPROTOTYPE:
-            return FIMO_EPROTOTYPE;
+            return FIMO_ERROR_CODE_PROTOTYPE;
 #endif // EPROTOTYPE
 
 #ifdef ERANGE
         case ERANGE:
-            return FIMO_ERANGE;
+            return FIMO_ERROR_CODE_RANGE;
 #endif // ERANGE
 
 #ifdef EREMCHG
         case EREMCHG:
-            return FIMO_EREMCHG;
+            return FIMO_ERROR_CODE_REMCHG;
 #endif // EREMCHG
 
 #ifdef EREMOTE
         case EREMOTE:
-            return FIMO_EREMOTE;
+            return FIMO_ERROR_CODE_REMOTE;
 #endif // EREMOTE
 
 #ifdef EREMOTEIO
         case EREMOTEIO:
-            return FIMO_EREMOTEIO;
+            return FIMO_ERROR_CODE_REMOTEIO;
 #endif // EREMOTEIO
 
 #ifdef ERESTART
         case ERESTART:
-            return FIMO_ERESTART;
+            return FIMO_ERROR_CODE_RESTART;
 #endif // ERESTART
 
 #ifdef ERFKILL
         case ERFKILL:
-            return FIMO_ERFKILL;
+            return FIMO_ERROR_CODE_RFKILL;
 #endif // ERFKILL
 
 #ifdef EROFS
         case EROFS:
-            return FIMO_EROFS;
+            return FIMO_ERROR_CODE_ROFS;
 #endif // EROFS
 
 #ifdef ESHUTDOWN
         case ESHUTDOWN:
-            return FIMO_ESHUTDOWN;
+            return FIMO_ERROR_CODE_SHUTDOWN;
 #endif // ESHUTDOWN
 
 #ifdef ESPIPE
         case ESPIPE:
-            return FIMO_ESPIPE;
+            return FIMO_ERROR_CODE_SPIPE;
 #endif // ESPIPE
 
 #ifdef ESOCKTNOSUPPORT
         case ESOCKTNOSUPPORT:
-            return FIMO_ESOCKTNOSUPPORT;
+            return FIMO_ERROR_CODE_SOCKTNOSUPPORT;
 #endif // ESOCKTNOSUPPORT
 
 #ifdef ESRCH
         case ESRCH:
-            return FIMO_ESRCH;
+            return FIMO_ERROR_CODE_SRCH;
 #endif // ESRCH
 
 #ifdef ESTALE
         case ESTALE:
-            return FIMO_ESTALE;
+            return FIMO_ERROR_CODE_STALE;
 #endif // ESTALE
 
 #ifdef ESTRPIPE
         case ESTRPIPE:
-            return FIMO_ESTRPIPE;
+            return FIMO_ERROR_CODE_STRPIPE;
 #endif // ESTRPIPE
 
 #ifdef ETIME
         case ETIME:
-            return FIMO_ETIME;
+            return FIMO_ERROR_CODE_TIME;
 #endif // ETIME
 
 #ifdef ETIMEDOUT
         case ETIMEDOUT:
-            return FIMO_ETIMEDOUT;
+            return FIMO_ERROR_CODE_TIMEDOUT;
 #endif // ETIMEDOUT
 
 #ifdef ETOOMANYREFS
         case ETOOMANYREFS:
-            return FIMO_ETOOMANYREFS;
+            return FIMO_ERROR_CODE_TOOMANYREFS;
 #endif // ETOOMANYREFS
 
 #ifdef ETXTBSY
         case ETXTBSY:
-            return FIMO_ETXTBSY;
+            return FIMO_ERROR_CODE_TXTBSY;
 #endif // ETXTBSY
 
 #ifdef EUCLEAN
         case EUCLEAN:
-            return FIMO_EUCLEAN;
+            return FIMO_ERROR_CODE_UCLEAN;
 #endif // EUCLEAN
 
 #ifdef EUNATCH
         case EUNATCH:
-            return FIMO_EUNATCH;
+            return FIMO_ERROR_CODE_UNATCH;
 #endif // EUNATCH
 
 #ifdef EUSERS
         case EUSERS:
-            return FIMO_EUSERS;
+            return FIMO_ERROR_CODE_USERS;
 #endif // EUSERS
 
 #ifdef EXDEV
         case EXDEV:
-            return FIMO_EXDEV;
+            return FIMO_ERROR_CODE_XDEV;
 #endif // EXDEV
 
 #ifdef EXFULL
         case EXFULL:
-            return FIMO_EXFULL;
+            return FIMO_ERROR_CODE_XFULL;
 #endif // EXFULL
 
         default:
-            return FIMO_EUNKNOWN;
+            return FIMO_ERROR_CODE_MAX + 1;
     }
 }
+
+static FimoResultString error_name_string_static_(void *data) {
+    return (FimoResultString){.str = data, .release = NULL};
+}
+
+static FimoResultString error_description_string_static_(void *data) {
+    return (FimoResultString){.str = data, .release = NULL};
+}
+
+const FimoResultVTable FIMO_IMPL_RESULT_STATIC_STRING_VTABLE = {
+        .v0 =
+                {
+                        .release = NULL,
+                        .error_name = error_name_string_static_,
+                        .error_description = error_description_string_static_,
+                },
+};
+
+static void free_string_dynamic_(void *data) { fimo_free(data); }
+
+static FimoResultString error_name_string_dynamic_(void *data) {
+    const char *str = data;
+    FimoUSize str_len = strlen(str);
+
+    FimoResult error = FIMO_EOK;
+    char *cpy = fimo_calloc(str_len + 1, &error);
+    if (FIMO_RESULT_IS_ERROR(error)) {
+        return fimo_result_error_name(error);
+    }
+    memcpy(cpy, str, str_len);
+    return (FimoResultString){.str = data, .release = NULL};
+}
+
+static FimoResultString error_description_string_dynamic_(void *data) {
+    const char *str = data;
+    FimoUSize str_len = strlen(str);
+
+    FimoResult error = FIMO_EOK;
+    char *cpy = fimo_calloc(str_len + 1, &error);
+    if (FIMO_RESULT_IS_ERROR(error)) {
+        return fimo_result_error_description(error);
+    }
+    memcpy(cpy, str, str_len);
+    return (FimoResultString){.str = data, .release = NULL};
+}
+
+const FimoResultVTable FIMO_IMPL_RESULT_DYNAMIC_STRING_VTABLE = {
+        .v0 =
+                {
+                        .release = free_string_dynamic_,
+                        .error_name = error_name_string_dynamic_,
+                        .error_description = error_description_string_dynamic_,
+                },
+};
+
+static FimoResultString error_name_error_code_(void *data) {
+    FIMO_PRAGMA_MSVC(warning(push))
+    FIMO_PRAGMA_MSVC(warning(disable : 4311))
+    FimoErrorCode error = (int)data;
+    FIMO_PRAGMA_MSVC(warning(pop))
+    return (FimoResultString){.str = fimo_error_code_name(error), .release = NULL};
+}
+
+static FimoResultString error_description_error_code_(void *data) {
+    FIMO_PRAGMA_MSVC(warning(push))
+    FIMO_PRAGMA_MSVC(warning(disable : 4311))
+    FimoErrorCode error = (int)data;
+    FIMO_PRAGMA_MSVC(warning(pop))
+    return (FimoResultString){.str = fimo_error_code_description(error), .release = NULL};
+}
+
+const FimoResultVTable FIMO_IMPL_RESULT_ERROR_CODE_VTABLE = {
+        .v0 =
+                {
+                        .release = NULL,
+                        .error_name = error_name_error_code_,
+                        .error_description = error_description_error_code_,
+                },
+};
+
+#ifdef _WIN32
+static void free_string_system_(const char *str) { LocalFree((char *)str); }
+#endif
+
+static FimoResultString error_name_system_(void *data) {
+    FIMO_PRAGMA_MSVC(warning(push))
+    FIMO_PRAGMA_MSVC(warning(disable : 4311))
+    FimoSystemErrorCode error = (FimoSystemErrorCode)data;
+    FIMO_PRAGMA_MSVC(warning(pop))
+#ifdef _WIN32
+    LPSTR error_name_template = "SystemError(%1!l!)";
+    DWORD_PTR error_name_args[] = {(DWORD_PTR)error};
+
+    LPSTR error_name = NULL;
+    if (!FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING | FORMAT_MESSAGE_ARGUMENT_ARRAY,
+                        error_name_template, 0, 0, (LPTSTR)&error_name, 0, (va_list *)error_name_args)) {
+        return (FimoResultString){.str = "SystemError(unknown)", .release = NULL};
+    }
+    return (FimoResultString){.str = error_name, .release = free_string_system_};
+#else
+    FimoErrorCode code = fimo_error_from_errno(error);
+    return {.str = fimo_error_code_name(code), .release = NULL};
+#endif
+}
+
+static FimoResultString error_description_system_(void *data) {
+    FIMO_PRAGMA_MSVC(warning(push))
+    FIMO_PRAGMA_MSVC(warning(disable : 4311))
+    FimoSystemErrorCode error = (FimoSystemErrorCode)data;
+    FIMO_PRAGMA_MSVC(warning(pop))
+#ifdef _WIN32
+    LPSTR error_description = NULL;
+    if (!FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_IGNORE_INSERTS,
+                        NULL, error, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR)error_description, 0, NULL)) {
+        return (FimoResultString){.str = "unknown error", .release = NULL};
+    }
+    return (FimoResultString){.str = error_description, .release = free_string_system_};
+#else
+    FimoErrorCode code = fimo_error_from_errno(error);
+    return {.str = fimo_error_code_description(code), .release = NULL};
+#endif
+}
+
+const FimoResultVTable FIMO_IMPL_RESULT_SYSTEM_ERROR_CODE_VTABLE = {
+        .v0 =
+                {
+                        .release = NULL,
+                        .error_name = error_name_system_,
+                        .error_description = error_description_system_,
+                },
+};
+
+const FimoResult FIMO_IMPL_RESULT_OK = {.data = NULL, .vtable = NULL};
+const FimoResult FIMO_IMPL_RESULT_INVALID_ERROR = {.data = "invalid error",
+                                                   .vtable = &FIMO_IMPL_RESULT_STATIC_STRING_VTABLE};
+const FimoResultString FIMO_IMPL_RESULT_OK_NAME = {.str = "ok", .release = NULL};
+const FimoResultString FIMO_IMPL_RESULT_OK_DESCRIPTION = {.str = "ok", .release = NULL};

--- a/ffi_library/fimo_std/src/impl/tracing.c
+++ b/ffi_library/fimo_std/src/impl/tracing.c
@@ -13,7 +13,7 @@
 
 #include <stdio.h>
 
-FimoError fimo_impl_tracing_fmt(char *buffer, FimoUSize buffer_size, const void *args, FimoUSize *written_size) {
+FimoResult fimo_impl_tracing_fmt(char *buffer, FimoUSize buffer_size, const void *args, FimoUSize *written_size) {
     if (buffer == NULL || args == NULL || written_size == NULL) {
         return FIMO_EINVAL;
     }
@@ -75,16 +75,17 @@ static void init_print_lock_(void) {
     FIMO_ASSERT(result == thrd_success);
 }
 
-FimoError fimo_impl_tracing_default_subscriber_call_stack_create(void *subscriber, const FimoTime *time, void **stack) {
+FimoResult fimo_impl_tracing_default_subscriber_call_stack_create(void *subscriber, const FimoTime *time,
+                                                                  void **stack) {
     (void)PRINT_BUFFER;
     (void)subscriber;
     (void)time;
 
     struct CallStack_ **stack_ = (struct CallStack_ **)stack;
 
-    FimoError error;
+    FimoResult error;
     *stack_ = fimo_malloc(sizeof(struct CallStack_), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
     **stack_ = (struct CallStack_){
@@ -132,18 +133,18 @@ void fimo_impl_tracing_default_subscriber_call_stack_resume(void *subscriber, co
     FIMO_DEBUG_ASSERT(stack);
 }
 
-FimoError fimo_impl_tracing_default_subscriber_span_push(void *subscriber, const FimoTime *time,
-                                                         const FimoTracingSpanDesc *span_desc, const char *message,
-                                                         const FimoUSize message_len, void *stack) {
+FimoResult fimo_impl_tracing_default_subscriber_span_push(void *subscriber, const FimoTime *time,
+                                                          const FimoTracingSpanDesc *span_desc, const char *message,
+                                                          const FimoUSize message_len, void *stack) {
     (void)subscriber;
     (void)time;
 
     struct CallStack_ *stack_ = stack;
     FIMO_DEBUG_ASSERT(stack_);
 
-    FimoError error;
+    FimoResult error;
     struct Span_ *span = fimo_malloc(sizeof(struct Span_), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
     *span = (struct Span_){

--- a/ffi_library/fimo_std/src/internal/context.c
+++ b/ffi_library/fimo_std/src/internal/context.c
@@ -71,13 +71,13 @@ static FimoVersion FIMO_IMPLEMENTED_VERSION =
         FIMO_VERSION_LONG(FIMO_VERSION_MAJOR, FIMO_VERSION_MINOR, FIMO_VERSION_PATCH, FIMO_VERSION_BUILD_NUMBER);
 
 FIMO_MUST_USE
-FimoError fimo_internal_context_init(const FimoBaseStructIn **options, FimoContext *context) {
+FimoResult fimo_internal_context_init(const FimoBaseStructIn **options, FimoContext *context) {
     if (context == NULL) {
         return FIMO_EINVAL;
     }
 
     // Parse the options. Each option type may occur at most once.
-    FimoError error;
+    FimoResult error;
     const FimoTracingCreationConfig *tracing_config = NULL;
     if (options != NULL) {
         for (const FimoBaseStructIn **cursor = options; *cursor != NULL; cursor++) {
@@ -100,20 +100,20 @@ FimoError fimo_internal_context_init(const FimoBaseStructIn **options, FimoConte
     options = NULL;
 
     FimoInternalContext *ctx = fimo_aligned_alloc(_Alignof(FimoInternalContext), sizeof(FimoInternalContext), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
     ctx->ref_count = (FimoAtomicRefCount)FIMO_REFCOUNT_INIT;
 
     error = fimo_internal_tracing_init(&ctx->tracing, tracing_config);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         goto cleanup;
     }
     tracing_config = NULL;
 
     error = fimo_internal_module_init(&ctx->module);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         goto deinit_tracing;
     }
 
@@ -146,7 +146,7 @@ cleanup_options:
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_context_to_public_ctx(void *ptr, FimoContext *context) {
+FimoResult fimo_internal_context_to_public_ctx(void *ptr, FimoContext *context) {
     if (ptr == NULL || context == NULL) {
         return FIMO_EINVAL;
     }
@@ -178,7 +178,7 @@ void fimo_internal_context_release(void *ptr) {
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_context_check_version(void *ptr, const FimoVersion *required) {
+FimoResult fimo_internal_context_check_version(void *ptr, const FimoVersion *required) {
     // Not strictly required, but we include it, in case we decide to embed
     // the version into the instance in the future.
     FimoInternalContext *context = ptr;

--- a/ffi_library/fimo_std/src/internal/tracing.c
+++ b/ffi_library/fimo_std/src/internal/tracing.c
@@ -34,16 +34,16 @@
 
 struct TSSData_;
 
-static FimoError tss_data_new_(FimoInternalTracingContext *ctx, struct TSSData_ **tss_data);
+static FimoResult tss_data_new_(FimoInternalTracingContext *ctx, struct TSSData_ **tss_data);
 static void tss_data_free_(struct TSSData_ *tss_data);
 
 struct StackFrame_;
 
-static FimoError stack_frame_new_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
-                                  FimoTracingFormat format, const void *data);
+static FimoResult stack_frame_new_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
+                                   FimoTracingFormat format, const void *data);
 static void stack_frame_free_(struct StackFrame_ *frame);
 
-static FimoError call_stack_new_(FimoInternalTracingContext *ctx, bool bound, FimoTracingCallStack **call_stack);
+static FimoResult call_stack_new_(FimoInternalTracingContext *ctx, bool bound, FimoTracingCallStack **call_stack);
 static void call_stack_free_(FimoTracingCallStack *call_stack, bool allow_bound);
 static bool call_stack_can_destroy_(FimoTracingCallStack *call_stack, bool allow_bound);
 static bool call_stack_is_bound_(FimoTracingCallStack *call_stack);
@@ -51,35 +51,35 @@ static bool call_stack_is_suspended_(FimoTracingCallStack *call_stack);
 static bool call_stack_is_blocked_(FimoTracingCallStack *call_stack);
 static bool call_stack_would_trace_(FimoTracingCallStack *call_stack, const FimoTracingMetadata *metadata);
 static bool call_stack_would_trace_(FimoTracingCallStack *call_stack, const FimoTracingMetadata *metadata);
-static FimoError call_stack_switch_(FimoTracingCallStack *call_stack, FimoTracingCallStack *old);
-static FimoError call_stack_unblock_(FimoTracingCallStack *call_stack);
-static FimoError call_stack_suspend_(FimoTracingCallStack *call_stack, bool block);
-static FimoError call_stack_resume_(FimoTracingCallStack *call_stack);
-static FimoError call_stack_create_span_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
-                                         FimoTracingSpan **span, FimoTracingFormat format, const void *data);
-static FimoError call_stack_destroy_span_(FimoTracingCallStack *call_stack, FimoTracingSpan *span);
-static FimoError call_stack_emit_event_(FimoTracingCallStack *call_stack, const FimoTracingEvent *event,
-                                        const FimoTracingFormat format, const void *data);
+static FimoResult call_stack_switch_(FimoTracingCallStack *call_stack, FimoTracingCallStack *old);
+static FimoResult call_stack_unblock_(FimoTracingCallStack *call_stack);
+static FimoResult call_stack_suspend_(FimoTracingCallStack *call_stack, bool block);
+static FimoResult call_stack_resume_(FimoTracingCallStack *call_stack);
+static FimoResult call_stack_create_span_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
+                                          FimoTracingSpan **span, FimoTracingFormat format, const void *data);
+static FimoResult call_stack_destroy_span_(FimoTracingCallStack *call_stack, FimoTracingSpan *span);
+static FimoResult call_stack_emit_event_(FimoTracingCallStack *call_stack, const FimoTracingEvent *event,
+                                         const FimoTracingFormat format, const void *data);
 
-static FimoError ctx_init_(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options);
+static FimoResult ctx_init_(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options);
 static void ctx_deinit_(FimoInternalTracingContext *ctx);
-static FimoError ctx_create_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack);
-static FimoError ctx_destroy_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
-static FimoError ctx_switch_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
-                                        FimoTracingCallStack **old);
-static FimoError ctx_unblock_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
-static FimoError ctx_suspend_current_call_stack_(FimoInternalTracingContext *ctx, bool block);
-static FimoError ctx_resume_current_call_stack_(FimoInternalTracingContext *ctx);
-static FimoError ctx_create_span_(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
-                                  FimoTracingSpan **span, FimoTracingFormat format, const void *data);
-static FimoError ctx_destroy_span_(FimoInternalTracingContext *ctx, FimoTracingSpan *span);
-static FimoError ctx_emit_event_(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
-                                 const FimoTracingFormat format, const void *data);
+static FimoResult ctx_create_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack);
+static FimoResult ctx_destroy_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
+static FimoResult ctx_switch_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
+                                         FimoTracingCallStack **old);
+static FimoResult ctx_unblock_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack);
+static FimoResult ctx_suspend_current_call_stack_(FimoInternalTracingContext *ctx, bool block);
+static FimoResult ctx_resume_current_call_stack_(FimoInternalTracingContext *ctx);
+static FimoResult ctx_create_span_(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
+                                   FimoTracingSpan **span, FimoTracingFormat format, const void *data);
+static FimoResult ctx_destroy_span_(FimoInternalTracingContext *ctx, FimoTracingSpan *span);
+static FimoResult ctx_emit_event_(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
+                                  const FimoTracingFormat format, const void *data);
 static bool ctx_is_enabled_(FimoInternalTracingContext *ctx);
 static bool ctx_is_enabled_for_thread_(FimoInternalTracingContext *ctx);
 static bool ctx_would_trace_(FimoInternalTracingContext *ctx, const FimoTracingMetadata *metadata);
-static FimoError ctx_register_thread_(FimoInternalTracingContext *ctx);
-static FimoError ctx_unregister_thread_(FimoInternalTracingContext *ctx);
+static FimoResult ctx_register_thread_(FimoInternalTracingContext *ctx);
+static FimoResult ctx_unregister_thread_(FimoInternalTracingContext *ctx);
 static void ctx_flush_(FimoInternalTracingContext *ctx);
 
 ///////////////////////////////////////////////////////////////////////
@@ -118,16 +118,16 @@ struct StackFrame_ {
     FimoTracingCallStack *call_stack;
 };
 
-static FimoError stack_frame_new_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
-                                  FimoTracingFormat format, const void *data) {
+static FimoResult stack_frame_new_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
+                                   FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(call_stack && span_desc && format)
 
     FimoUSize written_bytes;
     char *buffer_start = call_stack->buffer + call_stack->cursor;
     FimoUSize buffer_len = call_stack->ctx->buff_size - call_stack->cursor;
 
-    FimoError error = format(buffer_start, buffer_len, data, &written_bytes);
-    if (FIMO_IS_ERROR(error)) {
+    FimoResult error = format(buffer_start, buffer_len, data, &written_bytes);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
@@ -136,22 +136,22 @@ static FimoError stack_frame_new_(FimoTracingCallStack *call_stack, const FimoTr
     for (; num_spans < fimo_array_list_len(&call_stack->ctx->subscribers); num_spans++) {
         void **stack_;
         error = fimo_array_list_get(&call_stack->call_stacks, num_spans, sizeof(void *), (const void **)&stack_);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
 
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&call_stack->ctx->subscribers, num_spans, sizeof(FimoTracingSubscriber),
                                     (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
 
         error = subscriber->vtable->span_push(subscriber->ptr, &current_time, span_desc, buffer_start, written_bytes,
                                               *stack_);
-        if (FIMO_IS_ERROR(error)) {
+        if (FIMO_RESULT_IS_ERROR(error)) {
             goto cleanup;
         }
     }
 
     struct StackFrame_ *frame = fimo_malloc(sizeof(*frame), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         goto cleanup;
     }
 
@@ -187,17 +187,17 @@ static FimoError stack_frame_new_(FimoTracingCallStack *call_stack, const FimoTr
 cleanup:
     for (FimoUSize i = 0; i < num_spans; i++) {
         void **stack_;
-        FimoError error_ = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error_))
-        (void)error_;
+        FimoResult error_ = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error_))
+        FIMO_RESULT_IGNORE(error_);
 
         const FimoTracingSubscriber *subscriber;
         error_ = fimo_array_list_get(&call_stack->ctx->subscribers, i, sizeof(FimoTracingSubscriber),
                                      (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error_))
-        (void)error_;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error_))
+        FIMO_RESULT_IGNORE(error_);
 
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error_))
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error_))
         subscriber->vtable->span_drop(subscriber->ptr, *stack_);
     }
 
@@ -209,16 +209,16 @@ static void stack_frame_free_(struct StackFrame_ *frame) {
     const FimoTime current_time = fimo_time_now();
     for (FimoUSize i = 0; i < fimo_array_list_len(&frame->call_stack->ctx->subscribers); i++) {
         void **stack_;
-        FimoError error =
+        FimoResult error =
                 fimo_array_list_get(&frame->call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
 
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&frame->call_stack->ctx->subscribers, i, sizeof(FimoTracingSubscriber),
                                     (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
         subscriber->vtable->span_pop(subscriber->ptr, &current_time, *stack_);
     }
 
@@ -240,19 +240,19 @@ static void stack_frame_free_(struct StackFrame_ *frame) {
 //// Call Stack
 ///////////////////////////////////////////////////////////////////////
 
-static FimoError call_stack_new_(FimoInternalTracingContext *ctx, bool bound, FimoTracingCallStack **call_stack) {
+static FimoResult call_stack_new_(FimoInternalTracingContext *ctx, bool bound, FimoTracingCallStack **call_stack) {
     FIMO_DEBUG_ASSERT(ctx && call_stack)
 
-    FimoError error;
+    FimoResult error;
     char *buffer = fimo_calloc(ctx->buff_size, &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
     FimoArrayList call_stacks;
     error = fimo_array_list_with_capacity(fimo_array_list_len(&ctx->subscribers), sizeof(void *), alignof(void *),
                                           &call_stacks);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         fimo_free(buffer);
         return error;
     }
@@ -261,21 +261,21 @@ static FimoError call_stack_new_(FimoInternalTracingContext *ctx, bool bound, Fi
     for (FimoUSize i = 0; i < fimo_array_list_len(&ctx->subscribers); i++) {
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&ctx->subscribers, i, sizeof(FimoTracingSubscriber), (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
 
         void *stack_;
         error = subscriber->vtable->call_stack_create(subscriber->ptr, &current_time, &stack_);
-        if (FIMO_IS_ERROR(error)) {
+        if (FIMO_RESULT_IS_ERROR(error)) {
             goto cleanup_call_stacks;
         }
         error = fimo_array_list_try_push(&call_stacks, sizeof(void *), &stack_, NULL);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
     }
 
     unsigned int init_state = bound ? BOUND_BIT_ : SUSPENDED_BIT_;
 
     *call_stack = fimo_malloc(sizeof(**call_stack), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         goto cleanup_call_stacks;
     }
 
@@ -295,14 +295,14 @@ static FimoError call_stack_new_(FimoInternalTracingContext *ctx, bool bound, Fi
 cleanup_call_stacks:
     for (FimoUSize i = 0; !fimo_array_list_is_empty(&call_stacks); i++) {
         void *stack_;
-        FimoError error_ = fimo_array_list_pop_front(&call_stacks, sizeof(void *), &stack_, NULL);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error_))
-        (void)error_;
+        FimoResult error_ = fimo_array_list_pop_front(&call_stacks, sizeof(void *), &stack_, NULL);
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error_))
+        FIMO_RESULT_IGNORE(error_);
 
         const FimoTracingSubscriber *subscriber;
         error_ = fimo_array_list_get(&ctx->subscribers, i, sizeof(FimoTracingSubscriber), (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error_))
-        (void)error_;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error_))
+        FIMO_RESULT_IGNORE(error_);
         subscriber->vtable->call_stack_drop(subscriber->ptr, &stack_);
     }
 
@@ -319,15 +319,15 @@ static void call_stack_free_(FimoTracingCallStack *call_stack, bool allow_bound)
     const FimoTime current_time = fimo_time_now();
     for (FimoUSize i = 0; !fimo_array_list_is_empty(&call_stack->call_stacks); i++) {
         void *stack_;
-        FimoError error = fimo_array_list_pop_front(&call_stack->call_stacks, sizeof(void *), &stack_, NULL);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FimoResult error = fimo_array_list_pop_front(&call_stack->call_stacks, sizeof(void *), &stack_, NULL);
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
 
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&call_stack->ctx->subscribers, i, sizeof(FimoTracingSubscriber),
                                     (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
         subscriber->vtable->call_stack_destroy(subscriber->ptr, &current_time, stack_);
     }
     fimo_array_list_free(&call_stack->call_stacks, sizeof(void *), alignof(void *), NULL);
@@ -372,7 +372,7 @@ static bool call_stack_would_trace_(FimoTracingCallStack *call_stack, const Fimo
     return call_stack->max_level >= metadata->level;
 }
 
-static FimoError call_stack_switch_(FimoTracingCallStack *call_stack, FimoTracingCallStack *old) {
+static FimoResult call_stack_switch_(FimoTracingCallStack *call_stack, FimoTracingCallStack *old) {
     FIMO_DEBUG_ASSERT(call_stack && old && call_stack_is_bound_(old))
     FIMO_DEBUG_ASSERT_FALSE(call_stack == old)
 
@@ -402,7 +402,7 @@ static FimoError call_stack_switch_(FimoTracingCallStack *call_stack, FimoTracin
     return FIMO_EOK;
 }
 
-static FimoError call_stack_unblock_(FimoTracingCallStack *call_stack) {
+static FimoResult call_stack_unblock_(FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(call_stack)
 
     // We allow unblocking a call stack that is not bound,
@@ -427,15 +427,15 @@ static FimoError call_stack_unblock_(FimoTracingCallStack *call_stack) {
     const FimoTime current_time = fimo_time_now();
     for (FimoUSize i = 0; i < fimo_array_list_len(&call_stack->ctx->subscribers); i++) {
         void **stack_;
-        FimoError error = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FimoResult error = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
 
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&call_stack->ctx->subscribers, i, sizeof(FimoTracingSubscriber),
                                     (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
         subscriber->vtable->call_stack_unblock(subscriber->ptr, &current_time, *stack_);
     }
 
@@ -445,7 +445,7 @@ static FimoError call_stack_unblock_(FimoTracingCallStack *call_stack) {
     return FIMO_EOK;
 }
 
-static FimoError call_stack_suspend_(FimoTracingCallStack *call_stack, bool block) {
+static FimoResult call_stack_suspend_(FimoTracingCallStack *call_stack, bool block) {
     FIMO_DEBUG_ASSERT(call_stack && call_stack_is_bound_(call_stack))
     if (call_stack_is_suspended_(call_stack)) {
         return FIMO_EPERM;
@@ -459,22 +459,22 @@ static FimoError call_stack_suspend_(FimoTracingCallStack *call_stack, bool bloc
     const FimoTime current_time = fimo_time_now();
     for (FimoUSize i = 0; i < fimo_array_list_len(&call_stack->ctx->subscribers); i++) {
         void **stack_;
-        FimoError error = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FimoResult error = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
 
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&call_stack->ctx->subscribers, i, sizeof(FimoTracingSubscriber),
                                     (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
         subscriber->vtable->call_stack_suspend(subscriber->ptr, &current_time, *stack_, block);
     }
 
     return FIMO_EOK;
 }
 
-static FimoError call_stack_resume_(FimoTracingCallStack *call_stack) {
+static FimoResult call_stack_resume_(FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(call_stack && call_stack_is_bound_(call_stack))
     if (call_stack_is_blocked_(call_stack) || !call_stack_is_suspended_(call_stack)) {
         return FIMO_EPERM;
@@ -487,30 +487,30 @@ static FimoError call_stack_resume_(FimoTracingCallStack *call_stack) {
     const FimoTime current_time = fimo_time_now();
     for (FimoUSize i = 0; i < fimo_array_list_len(&call_stack->ctx->subscribers); i++) {
         void **stack_;
-        FimoError error = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FimoResult error = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
 
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&call_stack->ctx->subscribers, i, sizeof(FimoTracingSubscriber),
                                     (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
         subscriber->vtable->call_stack_resume(subscriber->ptr, &current_time, *stack_);
     }
 
     return FIMO_EOK;
 }
 
-static FimoError call_stack_create_span_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
-                                         FimoTracingSpan **span, FimoTracingFormat format, const void *data) {
+static FimoResult call_stack_create_span_(FimoTracingCallStack *call_stack, const FimoTracingSpanDesc *span_desc,
+                                          FimoTracingSpan **span, FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(call_stack && span_desc && span && format && call_stack_is_bound_(call_stack))
     if (call_stack_is_suspended_(call_stack)) {
         return FIMO_EPERM;
     }
 
-    FimoError error = stack_frame_new_(call_stack, span_desc, format, data);
-    if (FIMO_IS_ERROR(error)) {
+    FimoResult error = stack_frame_new_(call_stack, span_desc, format, data);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
@@ -520,7 +520,7 @@ static FimoError call_stack_create_span_(FimoTracingCallStack *call_stack, const
     return FIMO_EOK;
 }
 
-static FimoError call_stack_destroy_span_(FimoTracingCallStack *call_stack, FimoTracingSpan *span) {
+static FimoResult call_stack_destroy_span_(FimoTracingCallStack *call_stack, FimoTracingSpan *span) {
     FIMO_DEBUG_ASSERT(call_stack && span && call_stack_is_bound_(call_stack))
     if (call_stack_is_suspended_(call_stack)) {
         return FIMO_EPERM;
@@ -535,8 +535,8 @@ static FimoError call_stack_destroy_span_(FimoTracingCallStack *call_stack, Fimo
     return FIMO_EOK;
 }
 
-static FimoError call_stack_emit_event_(FimoTracingCallStack *call_stack, const FimoTracingEvent *event,
-                                        const FimoTracingFormat format, const void *data) {
+static FimoResult call_stack_emit_event_(FimoTracingCallStack *call_stack, const FimoTracingEvent *event,
+                                         const FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(call_stack && event && format && call_stack_is_bound_(call_stack))
     if (call_stack_is_suspended_(call_stack)) {
         return FIMO_EPERM;
@@ -549,8 +549,8 @@ static FimoError call_stack_emit_event_(FimoTracingCallStack *call_stack, const 
     FimoUSize buffer_len = call_stack->ctx->buff_size - call_stack->cursor;
 
     FimoUSize written_bytes = 0;
-    FimoError error = format(buffer_start, buffer_len, data, &written_bytes);
-    if (FIMO_IS_ERROR(error)) {
+    FimoResult error = format(buffer_start, buffer_len, data, &written_bytes);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
@@ -558,12 +558,12 @@ static FimoError call_stack_emit_event_(FimoTracingCallStack *call_stack, const 
     for (FimoUSize i = 0; i < fimo_array_list_len(&call_stack->ctx->subscribers); i++) {
         void **stack_;
         error = fimo_array_list_get(&call_stack->call_stacks, i, sizeof(void *), (const void **)&stack_);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
 
         const FimoTracingSubscriber *subscriber;
         error = fimo_array_list_get(&call_stack->ctx->subscribers, i, sizeof(FimoTracingSubscriber),
                                     (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
         subscriber->vtable->event_emit(subscriber->ptr, &current_time, *stack_, event, buffer_start, written_bytes);
     }
 
@@ -579,17 +579,17 @@ struct TSSData_ {
     FimoInternalTracingContext *ctx;
 };
 
-static FimoError tss_data_new_(FimoInternalTracingContext *ctx, struct TSSData_ **tss_data) {
+static FimoResult tss_data_new_(FimoInternalTracingContext *ctx, struct TSSData_ **tss_data) {
     FIMO_DEBUG_ASSERT(ctx && tss_data)
 
     FimoTracingCallStack *call_stack;
-    FimoError error = call_stack_new_(ctx, true, &call_stack);
-    if (FIMO_IS_ERROR(error)) {
+    FimoResult error = call_stack_new_(ctx, true, &call_stack);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
     *tss_data = fimo_malloc(sizeof(**tss_data), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         call_stack_free_(call_stack, true);
         return error;
     }
@@ -626,7 +626,7 @@ static void creation_config_cleanup_(const FimoTracingCreationConfig *options) {
 //// Context
 ///////////////////////////////////////////////////////////////////////
 
-static FimoError ctx_init_(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options) {
+static FimoResult ctx_init_(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options) {
     FIMO_DEBUG_ASSERT(ctx)
     FimoUSize format_buffer_size = 1024;
     FimoTracingLevel maximum_level = FIMO_TRACING_LEVEL_OFF;
@@ -636,9 +636,9 @@ static FimoError ctx_init_(FimoInternalTracingContext *ctx, const FimoTracingCre
             format_buffer_size = options->format_buffer_size;
         }
         maximum_level = options->maximum_level;
-        FimoError error = fimo_array_list_with_capacity(options->subscriber_count, sizeof(FimoTracingSubscriber),
-                                                        alignof(FimoTracingSubscriber), &subscribers);
-        if (FIMO_IS_ERROR(error)) {
+        FimoResult error = fimo_array_list_with_capacity(options->subscriber_count, sizeof(FimoTracingSubscriber),
+                                                         alignof(FimoTracingSubscriber), &subscribers);
+        if (FIMO_RESULT_IS_ERROR(error)) {
             creation_config_cleanup_(options);
             return error;
         }
@@ -646,7 +646,7 @@ static FimoError ctx_init_(FimoInternalTracingContext *ctx, const FimoTracingCre
         for (FimoUSize i = 0; i < options->subscriber_count; i++) {
             error = fimo_array_list_try_push(&subscribers, sizeof(FimoTracingSubscriber), &options->subscribers[i],
                                              NULL);
-            FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
+            FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
         }
     }
 
@@ -654,7 +654,7 @@ static FimoError ctx_init_(FimoInternalTracingContext *ctx, const FimoTracingCre
     if (tss_create(&local_data, (tss_dtor_t)tss_data_free_) != thrd_success) {
         fimo_array_list_free(&subscribers, sizeof(FimoTracingSubscriber), alignof(FimoTracingSubscriber),
                              (FimoArrayListDropFunc)subscriber_free_);
-        return FIMO_EUNKNOWN;
+        return FIMO_RESULT_FROM_STRING("could not create tss slot");
     }
 
     *ctx = (FimoInternalTracingContext){
@@ -691,7 +691,7 @@ static void ctx_deinit_(FimoInternalTracingContext *ctx) {
                          (FimoArrayListDropFunc)subscriber_free_);
 }
 
-static FimoError ctx_create_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack) {
+static FimoResult ctx_create_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack) {
     FIMO_DEBUG_ASSERT(ctx && call_stack)
     if (!ctx_is_enabled_(ctx)) {
         *call_stack = NULL;
@@ -701,7 +701,7 @@ static FimoError ctx_create_call_stack_(FimoInternalTracingContext *ctx, FimoTra
     return call_stack_new_(ctx, false, call_stack);
 }
 
-static FimoError ctx_destroy_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
+static FimoResult ctx_destroy_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     if (!ctx_is_enabled_(ctx)) {
         FIMO_DEBUG_ASSERT_FALSE(call_stack)
@@ -715,8 +715,8 @@ static FimoError ctx_destroy_call_stack_(FimoInternalTracingContext *ctx, FimoTr
     return FIMO_EOK;
 }
 
-static FimoError ctx_switch_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
-                                        FimoTracingCallStack **old) {
+static FimoResult ctx_switch_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
+                                         FimoTracingCallStack **old) {
     FIMO_DEBUG_ASSERT(ctx && old)
     if (!ctx_is_enabled_(ctx)) {
         FIMO_DEBUG_ASSERT_FALSE(call_stack)
@@ -736,8 +736,8 @@ static FimoError ctx_switch_call_stack_(FimoInternalTracingContext *ctx, FimoTra
         return FIMO_EINVAL;
     }
 
-    const FimoError error = call_stack_switch_(call_stack, local_data->active);
-    if (FIMO_IS_ERROR(error)) {
+    const FimoResult error = call_stack_switch_(call_stack, local_data->active);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
@@ -747,7 +747,7 @@ static FimoError ctx_switch_call_stack_(FimoInternalTracingContext *ctx, FimoTra
     return FIMO_EOK;
 }
 
-static FimoError ctx_unblock_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
+static FimoResult ctx_unblock_call_stack_(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     if (!ctx_is_enabled_(ctx)) {
         FIMO_DEBUG_ASSERT_FALSE(call_stack)
@@ -759,7 +759,7 @@ static FimoError ctx_unblock_call_stack_(FimoInternalTracingContext *ctx, FimoTr
     return call_stack_unblock_(call_stack);
 }
 
-static FimoError ctx_suspend_current_call_stack_(FimoInternalTracingContext *ctx, bool block) {
+static FimoResult ctx_suspend_current_call_stack_(FimoInternalTracingContext *ctx, bool block) {
     FIMO_DEBUG_ASSERT(ctx)
     if (!ctx_is_enabled_(ctx)) {
         return FIMO_EOK;
@@ -773,7 +773,7 @@ static FimoError ctx_suspend_current_call_stack_(FimoInternalTracingContext *ctx
     return call_stack_suspend_(local_data->active, block);
 }
 
-static FimoError ctx_resume_current_call_stack_(FimoInternalTracingContext *ctx) {
+static FimoResult ctx_resume_current_call_stack_(FimoInternalTracingContext *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     if (!ctx_is_enabled_(ctx)) {
         return FIMO_EOK;
@@ -787,8 +787,8 @@ static FimoError ctx_resume_current_call_stack_(FimoInternalTracingContext *ctx)
     return call_stack_resume_(local_data->active);
 }
 
-static FimoError ctx_create_span_(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
-                                  FimoTracingSpan **span, FimoTracingFormat format, const void *data) {
+static FimoResult ctx_create_span_(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
+                                   FimoTracingSpan **span, FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(ctx && span_desc && span && format)
     if (!ctx_is_enabled_(ctx)) {
         *span = NULL;
@@ -803,7 +803,7 @@ static FimoError ctx_create_span_(FimoInternalTracingContext *ctx, const FimoTra
     return call_stack_create_span_(local_data->active, span_desc, span, format, data);
 }
 
-static FimoError ctx_destroy_span_(FimoInternalTracingContext *ctx, FimoTracingSpan *span) {
+static FimoResult ctx_destroy_span_(FimoInternalTracingContext *ctx, FimoTracingSpan *span) {
     FIMO_DEBUG_ASSERT(ctx)
     if (!ctx_is_enabled_(ctx)) {
         FIMO_DEBUG_ASSERT(span == NULL)
@@ -819,8 +819,8 @@ static FimoError ctx_destroy_span_(FimoInternalTracingContext *ctx, FimoTracingS
     return call_stack_destroy_span_(local_data->active, span);
 }
 
-static FimoError ctx_emit_event_(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
-                                 const FimoTracingFormat format, const void *data) {
+static FimoResult ctx_emit_event_(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
+                                  const FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(ctx && event && format)
     if (!ctx_would_trace_(ctx, event->metadata)) {
         return FIMO_EOK;
@@ -846,7 +846,7 @@ static bool ctx_would_trace_(FimoInternalTracingContext *ctx, const FimoTracingM
     return ctx_is_enabled_for_thread_(ctx) && ctx->max_level >= metadata->level;
 }
 
-static FimoError ctx_register_thread_(FimoInternalTracingContext *ctx) {
+static FimoResult ctx_register_thread_(FimoInternalTracingContext *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     if (!ctx_is_enabled_(ctx)) {
         return FIMO_EOK;
@@ -857,8 +857,8 @@ static FimoError ctx_register_thread_(FimoInternalTracingContext *ctx) {
     }
 
     struct TSSData_ *local_data;
-    const FimoError error = tss_data_new_(ctx, &local_data);
-    if (FIMO_IS_ERROR(error)) {
+    const FimoResult error = tss_data_new_(ctx, &local_data);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
     const int result = tss_set(ctx->tss_data, local_data);
@@ -868,7 +868,7 @@ static FimoError ctx_register_thread_(FimoInternalTracingContext *ctx) {
     return FIMO_EOK;
 }
 
-static FimoError ctx_unregister_thread_(FimoInternalTracingContext *ctx) {
+static FimoResult ctx_unregister_thread_(FimoInternalTracingContext *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     if (!ctx_is_enabled_(ctx)) {
         return FIMO_EOK;
@@ -895,10 +895,10 @@ static void ctx_flush_(FimoInternalTracingContext *ctx) {
 
     for (FimoUSize i = 0; i < fimo_array_list_len(&ctx->subscribers); i++) {
         const FimoTracingSubscriber *subscriber;
-        const FimoError error =
+        const FimoResult error =
                 fimo_array_list_get(&ctx->subscribers, i, sizeof(FimoTracingSubscriber), (const void **)&subscriber);
-        FIMO_DEBUG_ASSERT_FALSE(FIMO_IS_ERROR(error))
-        (void)error;
+        FIMO_DEBUG_ASSERT_FALSE(FIMO_RESULT_IS_ERROR(error))
+        FIMO_RESULT_IGNORE(error);
         subscriber->vtable->flush(subscriber->ptr);
     }
 }
@@ -907,52 +907,52 @@ static void ctx_flush_(FimoInternalTracingContext *ctx) {
 //// Trampoline functions
 ///////////////////////////////////////////////////////////////////////
 
-FimoError fimo_internal_trampoline_tracing_call_stack_create(void *ctx, FimoTracingCallStack **call_stack) {
+FimoResult fimo_internal_trampoline_tracing_call_stack_create(void *ctx, FimoTracingCallStack **call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_call_stack_create(&((FimoInternalContext *)ctx)->tracing, call_stack);
 }
 
-FimoError fimo_internal_trampoline_tracing_call_stack_destroy(void *ctx, FimoTracingCallStack *call_stack) {
+FimoResult fimo_internal_trampoline_tracing_call_stack_destroy(void *ctx, FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_call_stack_destroy(&((FimoInternalContext *)ctx)->tracing, call_stack);
 }
 
-FimoError fimo_internal_trampoline_tracing_call_stack_switch(void *ctx, FimoTracingCallStack *call_stack,
-                                                             FimoTracingCallStack **old) {
+FimoResult fimo_internal_trampoline_tracing_call_stack_switch(void *ctx, FimoTracingCallStack *call_stack,
+                                                              FimoTracingCallStack **old) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_call_stack_switch(&((FimoInternalContext *)ctx)->tracing, call_stack, old);
 }
 
-FimoError fimo_internal_trampoline_tracing_call_stack_unblock(void *ctx, FimoTracingCallStack *call_stack) {
+FimoResult fimo_internal_trampoline_tracing_call_stack_unblock(void *ctx, FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_call_stack_unblock(&((FimoInternalContext *)ctx)->tracing, call_stack);
 }
 
-FimoError fimo_internal_trampoline_tracing_call_stack_suspend_current(void *ctx, const bool block) {
+FimoResult fimo_internal_trampoline_tracing_call_stack_suspend_current(void *ctx, const bool block) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_call_stack_suspend_current(&((FimoInternalContext *)ctx)->tracing, block);
 }
 
-FimoError fimo_internal_trampoline_tracing_call_stack_resume_current(void *ctx) {
+FimoResult fimo_internal_trampoline_tracing_call_stack_resume_current(void *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_call_stack_resume_current(&((FimoInternalContext *)ctx)->tracing);
 }
 
-FimoError fimo_internal_trampoline_tracing_span_create(void *ctx, const FimoTracingSpanDesc *span_desc,
-                                                       FimoTracingSpan **span, FimoTracingFormat format,
-                                                       const void *data) {
+FimoResult fimo_internal_trampoline_tracing_span_create(void *ctx, const FimoTracingSpanDesc *span_desc,
+                                                        FimoTracingSpan **span, FimoTracingFormat format,
+                                                        const void *data) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_span_create_custom(&((FimoInternalContext *)ctx)->tracing, span_desc, span, format,
                                                     data);
 }
 
-FimoError fimo_internal_trampoline_tracing_span_destroy(void *ctx, FimoTracingSpan *span) {
+FimoResult fimo_internal_trampoline_tracing_span_destroy(void *ctx, FimoTracingSpan *span) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_span_destroy(&((FimoInternalContext *)ctx)->tracing, span);
 }
 
-FimoError fimo_internal_trampoline_tracing_event_emit(void *ctx, const FimoTracingEvent *event,
-                                                      FimoTracingFormat format, const void *data) {
+FimoResult fimo_internal_trampoline_tracing_event_emit(void *ctx, const FimoTracingEvent *event,
+                                                       FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_event_emit_custom(&((FimoInternalContext *)ctx)->tracing, event, format, data);
 }
@@ -962,17 +962,17 @@ bool fimo_internal_trampoline_tracing_is_enabled(void *ctx) {
     return fimo_internal_tracing_is_enabled(&((FimoInternalContext *)ctx)->tracing);
 }
 
-FimoError fimo_internal_trampoline_tracing_register_thread(void *ctx) {
+FimoResult fimo_internal_trampoline_tracing_register_thread(void *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_register_thread(&((FimoInternalContext *)ctx)->tracing);
 }
 
-FimoError fimo_internal_trampoline_tracing_unregister_thread(void *ctx) {
+FimoResult fimo_internal_trampoline_tracing_unregister_thread(void *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_unregister_thread(&((FimoInternalContext *)ctx)->tracing);
 }
 
-FimoError fimo_internal_trampoline_tracing_flush(void *ctx) {
+FimoResult fimo_internal_trampoline_tracing_flush(void *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     return fimo_internal_tracing_flush(&((FimoInternalContext *)ctx)->tracing);
 }
@@ -982,7 +982,7 @@ FimoError fimo_internal_trampoline_tracing_flush(void *ctx) {
 ///////////////////////////////////////////////////////////////////////
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_init(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options) {
+FimoResult fimo_internal_tracing_init(FimoInternalTracingContext *ctx, const FimoTracingCreationConfig *options) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_init_(ctx, options);
 }
@@ -998,7 +998,7 @@ void fimo_internal_tracing_cleanup_options(const FimoTracingCreationConfig *opti
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_create(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack) {
+FimoResult fimo_internal_tracing_call_stack_create(FimoInternalTracingContext *ctx, FimoTracingCallStack **call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     if (call_stack == NULL) {
         return FIMO_EINVAL;
@@ -1007,14 +1007,14 @@ FimoError fimo_internal_tracing_call_stack_create(FimoInternalTracingContext *ct
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_destroy(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
+FimoResult fimo_internal_tracing_call_stack_destroy(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_destroy_call_stack_(ctx, call_stack);
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_switch(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
-                                                  FimoTracingCallStack **old) {
+FimoResult fimo_internal_tracing_call_stack_switch(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack,
+                                                   FimoTracingCallStack **old) {
     FIMO_DEBUG_ASSERT(ctx)
     if (old == NULL) {
         return FIMO_EINVAL;
@@ -1023,27 +1023,27 @@ FimoError fimo_internal_tracing_call_stack_switch(FimoInternalTracingContext *ct
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_unblock(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
+FimoResult fimo_internal_tracing_call_stack_unblock(FimoInternalTracingContext *ctx, FimoTracingCallStack *call_stack) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_unblock_call_stack_(ctx, call_stack);
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_suspend_current(FimoInternalTracingContext *ctx, const bool block) {
+FimoResult fimo_internal_tracing_call_stack_suspend_current(FimoInternalTracingContext *ctx, const bool block) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_suspend_current_call_stack_(ctx, block);
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_call_stack_resume_current(FimoInternalTracingContext *ctx) {
+FimoResult fimo_internal_tracing_call_stack_resume_current(FimoInternalTracingContext *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_resume_current_call_stack_(ctx);
 }
 
 FIMO_PRINT_F_FORMAT_ATTR(4, 5)
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_span_create_fmt(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
-                                                FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...) {
+FimoResult fimo_internal_tracing_span_create_fmt(FimoInternalTracingContext *ctx, const FimoTracingSpanDesc *span_desc,
+                                                 FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...) {
     FIMO_DEBUG_ASSERT(ctx)
     if (span_desc == NULL || span == NULL || format == NULL) {
         return FIMO_EINVAL;
@@ -1052,16 +1052,16 @@ FimoError fimo_internal_tracing_span_create_fmt(FimoInternalTracingContext *ctx,
     va_list vlist;
     va_start(vlist, format);
     FimoImplTracingFmtArgs args = {.format = format, .vlist = &vlist};
-    const FimoError result =
+    const FimoResult result =
             fimo_internal_tracing_span_create_custom(ctx, span_desc, span, fimo_impl_tracing_fmt, &args);
     va_end(vlist);
     return result;
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_span_create_custom(FimoInternalTracingContext *ctx,
-                                                   const FimoTracingSpanDesc *span_desc, FimoTracingSpan **span,
-                                                   FimoTracingFormat format, const void *data) {
+FimoResult fimo_internal_tracing_span_create_custom(FimoInternalTracingContext *ctx,
+                                                    const FimoTracingSpanDesc *span_desc, FimoTracingSpan **span,
+                                                    FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(ctx)
     if (span_desc == NULL || span == NULL || format == NULL) {
         return FIMO_EINVAL;
@@ -1070,15 +1070,15 @@ FimoError fimo_internal_tracing_span_create_custom(FimoInternalTracingContext *c
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_span_destroy(FimoInternalTracingContext *ctx, FimoTracingSpan *span) {
+FimoResult fimo_internal_tracing_span_destroy(FimoInternalTracingContext *ctx, FimoTracingSpan *span) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_destroy_span_(ctx, span);
 }
 
 FIMO_PRINT_F_FORMAT_ATTR(3, 4)
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_event_emit_fmt(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
-                                               FIMO_PRINT_F_FORMAT const char *format, ...) {
+FimoResult fimo_internal_tracing_event_emit_fmt(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
+                                                FIMO_PRINT_F_FORMAT const char *format, ...) {
     FIMO_DEBUG_ASSERT(ctx)
     if (event == NULL || format == NULL) {
         return FIMO_EINVAL;
@@ -1087,14 +1087,14 @@ FimoError fimo_internal_tracing_event_emit_fmt(FimoInternalTracingContext *ctx, 
     va_list vlist;
     va_start(vlist, format);
     FimoImplTracingFmtArgs args = {.format = format, .vlist = &vlist};
-    const FimoError result = fimo_internal_tracing_event_emit_custom(ctx, event, fimo_impl_tracing_fmt, &args);
+    const FimoResult result = fimo_internal_tracing_event_emit_custom(ctx, event, fimo_impl_tracing_fmt, &args);
     va_end(vlist);
     return result;
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_event_emit_custom(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
-                                                  const FimoTracingFormat format, const void *data) {
+FimoResult fimo_internal_tracing_event_emit_custom(FimoInternalTracingContext *ctx, const FimoTracingEvent *event,
+                                                   const FimoTracingFormat format, const void *data) {
     FIMO_DEBUG_ASSERT(ctx)
     if (event == NULL || format == NULL) {
         return FIMO_EINVAL;
@@ -1109,19 +1109,19 @@ bool fimo_internal_tracing_is_enabled(FimoInternalTracingContext *ctx) {
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_register_thread(FimoInternalTracingContext *ctx) {
+FimoResult fimo_internal_tracing_register_thread(FimoInternalTracingContext *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_register_thread_(ctx);
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_unregister_thread(FimoInternalTracingContext *ctx) {
+FimoResult fimo_internal_tracing_unregister_thread(FimoInternalTracingContext *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     return ctx_unregister_thread_(ctx);
 }
 
 FIMO_MUST_USE
-FimoError fimo_internal_tracing_flush(FimoInternalTracingContext *ctx) {
+FimoResult fimo_internal_tracing_flush(FimoInternalTracingContext *ctx) {
     FIMO_DEBUG_ASSERT(ctx)
     ctx_flush_(ctx);
     return FIMO_EOK;

--- a/ffi_library/fimo_std/src/memory.c
+++ b/ffi_library/fimo_std/src/memory.c
@@ -17,27 +17,27 @@
 
 FIMO_EXPORT
 FIMO_MUST_USE
-void *fimo_malloc(const size_t size, FimoError *error) { return fimo_malloc_sized(size, error).ptr; }
+void *fimo_malloc(const size_t size, FimoResult *error) { return fimo_malloc_sized(size, error).ptr; }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-void *fimo_calloc(const size_t size, FimoError *error) { return fimo_calloc_sized(size, error).ptr; }
+void *fimo_calloc(const size_t size, FimoResult *error) { return fimo_calloc_sized(size, error).ptr; }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-void *fimo_aligned_alloc(const size_t alignment, const size_t size, FimoError *error) {
+void *fimo_aligned_alloc(const size_t alignment, const size_t size, FimoResult *error) {
     return fimo_aligned_alloc_sized(alignment, size, error).ptr;
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoMallocBuffer fimo_malloc_sized(const size_t size, FimoError *error) {
+FimoMallocBuffer fimo_malloc_sized(const size_t size, FimoResult *error) {
     return fimo_aligned_alloc_sized(FIMO_MALLOC_ALIGNMENT, size, error);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoMallocBuffer fimo_calloc_sized(const size_t size, FimoError *error) {
+FimoMallocBuffer fimo_calloc_sized(const size_t size, FimoResult *error) {
     const FimoMallocBuffer buffer = fimo_malloc_sized(size, error);
     if (buffer.ptr == NULL) {
         return buffer;
@@ -50,7 +50,7 @@ FimoMallocBuffer fimo_calloc_sized(const size_t size, FimoError *error) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoMallocBuffer fimo_aligned_alloc_sized(size_t alignment, size_t size, FimoError *error) {
+FimoMallocBuffer fimo_aligned_alloc_sized(size_t alignment, size_t size, FimoResult *error) {
     if (size == 0 || alignment == 0 || ((alignment & (alignment - 1)) != 0)) {
         if (error) {
             *error = size == 0 ? FIMO_EOK : FIMO_EINVAL;
@@ -77,7 +77,7 @@ FimoMallocBuffer fimo_aligned_alloc_sized(size_t alignment, size_t size, FimoErr
 #endif // defined(_WIN32) || defined(WIN32)
     if (ptr == NULL) {
         if (error) {
-            *error = fimo_error_from_errno(errno);
+            *error = FIMO_RESULT_FROM_ERROR_CODE(fimo_error_code_from_errno(errno));
         }
         return (FimoMallocBuffer){.ptr = NULL, .buff_size = 0};
     }
@@ -86,7 +86,7 @@ FimoMallocBuffer fimo_aligned_alloc_sized(size_t alignment, size_t size, FimoErr
     buff_size = _aligned_msize(ptr, alignment, 0);
     if (buff_size == (size_t)-1) {
         if (error) {
-            *error = fimo_error_from_errno(errno);
+            *error = FIMO_RESULT_FROM_ERROR_CODE(fimo_error_code_from_errno(errno));
         }
         _aligned_free(ptr);
         return (FimoMallocBuffer){.ptr = NULL, .buff_size = 0};

--- a/ffi_library/fimo_std/src/module.c
+++ b/ffi_library/fimo_std/src/module.c
@@ -38,7 +38,7 @@ bool fimo_impl_module_info_is_loaded(const FimoModuleInfo *info) {
 }
 
 FIMO_EXPORT
-FimoError fimo_impl_module_info_lock_unload(const FimoModuleInfo *info) {
+FimoResult fimo_impl_module_info_lock_unload(const FimoModuleInfo *info) {
     FIMO_DEBUG_ASSERT(info)
     return info->lock_unload(info);
 }
@@ -52,14 +52,14 @@ void fimo_impl_module_info_unlock_unload(const FimoModuleInfo *info) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_pseudo_module_new(const FimoContext context, const FimoModule **module) {
+FimoResult fimo_module_pseudo_module_new(const FimoContext context, const FimoModule **module) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.pseudo_module_new(context.data, module);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_pseudo_module_destroy(const FimoModule *module, FimoContext *module_context) {
+FimoResult fimo_module_pseudo_module_destroy(const FimoModule *module, FimoContext *module_context) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -69,32 +69,32 @@ FimoError fimo_module_pseudo_module_destroy(const FimoModule *module, FimoContex
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_new(const FimoContext context, FimoModuleLoadingSet **module_set) {
+FimoResult fimo_module_set_new(const FimoContext context, FimoModuleLoadingSet **module_set) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.set_new(context.data, module_set);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_has_module(const FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
-                                     bool *has_module) {
+FimoResult fimo_module_set_has_module(const FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
+                                      bool *has_module) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.set_has_module(context.data, module_set, name, has_module);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_has_symbol(const FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
-                                     const char *ns, const FimoVersion version, bool *has_symbol) {
+FimoResult fimo_module_set_has_symbol(const FimoContext context, FimoModuleLoadingSet *module_set, const char *name,
+                                      const char *ns, const FimoVersion version, bool *has_symbol) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.set_has_symbol(context.data, module_set, name, ns, version, has_symbol);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_append_callback(const FimoContext context, FimoModuleLoadingSet *module_set,
-                                          const char *module_name, const FimoModuleLoadingSuccessCallback on_success,
-                                          const FimoModuleLoadingErrorCallback on_error, void *user_data) {
+FimoResult fimo_module_set_append_callback(const FimoContext context, FimoModuleLoadingSet *module_set,
+                                           const char *module_name, const FimoModuleLoadingSuccessCallback on_success,
+                                           const FimoModuleLoadingErrorCallback on_error, void *user_data) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.set_append_callback(context.data, module_set, module_name, on_success, on_error,
                                                  user_data);
@@ -102,8 +102,8 @@ FimoError fimo_module_set_append_callback(const FimoContext context, FimoModuleL
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_append_freestanding_module(const FimoModule *module, FimoModuleLoadingSet *module_set,
-                                                     const FimoModuleExport *module_export) {
+FimoResult fimo_module_set_append_freestanding_module(const FimoModule *module, FimoModuleLoadingSet *module_set,
+                                                      const FimoModuleExport *module_export) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -113,9 +113,9 @@ FimoError fimo_module_set_append_freestanding_module(const FimoModule *module, F
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_append_modules(const FimoContext context, FimoModuleLoadingSet *module_set,
-                                         const char *module_path, const FimoModuleLoadingFilter filter,
-                                         void *filter_data) {
+FimoResult fimo_module_set_append_modules(const FimoContext context, FimoModuleLoadingSet *module_set,
+                                          const char *module_path, const FimoModuleLoadingFilter filter,
+                                          void *filter_data) {
     void (*iterator)(bool (*)(const FimoModuleExport *, void *), void *) = fimo_impl_module_export_iterator;
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.set_append_modules(context.data, module_set, module_path, filter, filter_data,
@@ -124,43 +124,43 @@ FimoError fimo_module_set_append_modules(const FimoContext context, FimoModuleLo
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_dismiss(const FimoContext context, FimoModuleLoadingSet *module_set) {
+FimoResult fimo_module_set_dismiss(const FimoContext context, FimoModuleLoadingSet *module_set) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.set_dismiss(context.data, module_set);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_set_finish(const FimoContext context, FimoModuleLoadingSet *module_set) {
+FimoResult fimo_module_set_finish(const FimoContext context, FimoModuleLoadingSet *module_set) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.set_finish(context.data, module_set);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_find_by_name(const FimoContext context, const char *name, const FimoModuleInfo **module) {
+FimoResult fimo_module_find_by_name(const FimoContext context, const char *name, const FimoModuleInfo **module) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.find_by_name(context.data, name, module);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_find_by_symbol(const FimoContext context, const char *name, const char *ns,
-                                     const FimoVersion version, const FimoModuleInfo **module) {
+FimoResult fimo_module_find_by_symbol(const FimoContext context, const char *name, const char *ns,
+                                      const FimoVersion version, const FimoModuleInfo **module) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.find_by_symbol(context.data, name, ns, version, module);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_exists(const FimoContext context, const char *ns, bool *exists) {
+FimoResult fimo_module_namespace_exists(const FimoContext context, const char *ns, bool *exists) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.namespace_exists(context.data, ns, exists);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_include(const FimoModule *module, const char *ns) {
+FimoResult fimo_module_namespace_include(const FimoModule *module, const char *ns) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -170,7 +170,7 @@ FimoError fimo_module_namespace_include(const FimoModule *module, const char *ns
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_exclude(const FimoModule *module, const char *ns) {
+FimoResult fimo_module_namespace_exclude(const FimoModule *module, const char *ns) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -180,7 +180,8 @@ FimoError fimo_module_namespace_exclude(const FimoModule *module, const char *ns
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_namespace_included(const FimoModule *module, const char *ns, bool *is_included, bool *is_static) {
+FimoResult fimo_module_namespace_included(const FimoModule *module, const char *ns, bool *is_included,
+                                          bool *is_static) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -190,7 +191,7 @@ FimoError fimo_module_namespace_included(const FimoModule *module, const char *n
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_acquire_dependency(const FimoModule *module, const FimoModuleInfo *dependency) {
+FimoResult fimo_module_acquire_dependency(const FimoModule *module, const FimoModuleInfo *dependency) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -200,7 +201,7 @@ FimoError fimo_module_acquire_dependency(const FimoModule *module, const FimoMod
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_relinquish_dependency(const FimoModule *module, const FimoModuleInfo *dependency) {
+FimoResult fimo_module_relinquish_dependency(const FimoModule *module, const FimoModuleInfo *dependency) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -210,8 +211,8 @@ FimoError fimo_module_relinquish_dependency(const FimoModule *module, const Fimo
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_has_dependency(const FimoModule *module, const FimoModuleInfo *other, bool *has_dependency,
-                                     bool *is_static) {
+FimoResult fimo_module_has_dependency(const FimoModule *module, const FimoModuleInfo *other, bool *has_dependency,
+                                      bool *is_static) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -221,8 +222,8 @@ FimoError fimo_module_has_dependency(const FimoModule *module, const FimoModuleI
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_load_symbol(const FimoModule *module, const char *name, const char *ns, const FimoVersion version,
-                                  const FimoModuleRawSymbol **symbol) {
+FimoResult fimo_module_load_symbol(const FimoModule *module, const char *name, const char *ns,
+                                   const FimoVersion version, const FimoModuleRawSymbol **symbol) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -232,40 +233,40 @@ FimoError fimo_module_load_symbol(const FimoModule *module, const char *name, co
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_unload(const FimoContext context, const FimoModuleInfo *module) {
+FimoResult fimo_module_unload(const FimoContext context, const FimoModuleInfo *module) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.unload(context.data, module);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_query(const FimoContext context, const char *module_name, const char *param,
-                                  FimoModuleParamType *type, FimoModuleParamAccess *read,
-                                  FimoModuleParamAccess *write) {
+FimoResult fimo_module_param_query(const FimoContext context, const char *module_name, const char *param,
+                                   FimoModuleParamType *type, FimoModuleParamAccess *read,
+                                   FimoModuleParamAccess *write) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.param_query(context.data, module_name, param, type, read, write);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_public(const FimoContext context, const void *value, const FimoModuleParamType type,
-                                       const char *module_name, const char *param) {
+FimoResult fimo_module_param_set_public(const FimoContext context, const void *value, const FimoModuleParamType type,
+                                        const char *module_name, const char *param) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.param_set_public(context.data, value, type, module_name, param);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_public(const FimoContext context, void *value, FimoModuleParamType *type,
-                                       const char *module_name, const char *param) {
+FimoResult fimo_module_param_get_public(const FimoContext context, void *value, FimoModuleParamType *type,
+                                        const char *module_name, const char *param) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->module_v0.param_get_public(context.data, value, type, module_name, param);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_dependency(const FimoModule *module, const void *value, const FimoModuleParamType type,
-                                           const char *module_name, const char *param) {
+FimoResult fimo_module_param_set_dependency(const FimoModule *module, const void *value, const FimoModuleParamType type,
+                                            const char *module_name, const char *param) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -275,8 +276,8 @@ FimoError fimo_module_param_set_dependency(const FimoModule *module, const void 
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_dependency(const FimoModule *module, void *value, FimoModuleParamType *type,
-                                           const char *module_name, const char *param) {
+FimoResult fimo_module_param_get_dependency(const FimoModule *module, void *value, FimoModuleParamType *type,
+                                            const char *module_name, const char *param) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -286,8 +287,8 @@ FimoError fimo_module_param_get_dependency(const FimoModule *module, void *value
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_private(const FimoModule *module, const void *value, const FimoModuleParamType type,
-                                        FimoModuleParam *param) {
+FimoResult fimo_module_param_set_private(const FimoModule *module, const void *value, const FimoModuleParamType type,
+                                         FimoModuleParam *param) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -297,8 +298,8 @@ FimoError fimo_module_param_set_private(const FimoModule *module, const void *va
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_private(const FimoModule *module, void *value, FimoModuleParamType *type,
-                                        const FimoModuleParam *param) {
+FimoResult fimo_module_param_get_private(const FimoModule *module, void *value, FimoModuleParamType *type,
+                                         const FimoModuleParam *param) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -308,8 +309,8 @@ FimoError fimo_module_param_get_private(const FimoModule *module, void *value, F
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_set_inner(const FimoModule *module, const void *value, const FimoModuleParamType type,
-                                      FimoModuleParamData *param) {
+FimoResult fimo_module_param_set_inner(const FimoModule *module, const void *value, const FimoModuleParamType type,
+                                       FimoModuleParamData *param) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }
@@ -319,8 +320,8 @@ FimoError fimo_module_param_set_inner(const FimoModule *module, const void *valu
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_module_param_get_inner(const FimoModule *module, void *value, FimoModuleParamType *type,
-                                      const FimoModuleParamData *param) {
+FimoResult fimo_module_param_get_inner(const FimoModule *module, void *value, FimoModuleParamType *type,
+                                       const FimoModuleParamData *param) {
     if (module == NULL) {
         return FIMO_EINVAL;
     }

--- a/ffi_library/fimo_std/src/refcount.c
+++ b/ffi_library/fimo_std/src/refcount.c
@@ -141,7 +141,7 @@ bool fimo_decrease_weak_count_atomic(FimoAtomicRefCount *count) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_upgrade_refcount(FimoRefCount *count) {
+FimoResult fimo_upgrade_refcount(FimoRefCount *count) {
     FIMO_DEBUG_ASSERT(count)
     if (count->strong_refs == 0) {
         return FIMO_EINVAL;
@@ -155,7 +155,7 @@ FimoError fimo_upgrade_refcount(FimoRefCount *count) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_upgrade_refcount_atomic(FimoAtomicRefCount *count) {
+FimoResult fimo_upgrade_refcount_atomic(FimoAtomicRefCount *count) {
     FIMO_DEBUG_ASSERT(count)
     // CAS loop
     FimoUSize expected_count = atomic_load_explicit(&count->strong_refs, memory_order_relaxed);
@@ -175,7 +175,7 @@ FimoError fimo_upgrade_refcount_atomic(FimoAtomicRefCount *count) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_downgrade_refcount(FimoRefCount *count) {
+FimoResult fimo_downgrade_refcount(FimoRefCount *count) {
     FIMO_DEBUG_ASSERT(count)
     if (count->weak_refs > MAX_REFCOUNT) {
         return FIMO_EOVERFLOW;
@@ -186,7 +186,7 @@ FimoError fimo_downgrade_refcount(FimoRefCount *count) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_downgrade_refcount_atomic(FimoAtomicRefCount *count) {
+FimoResult fimo_downgrade_refcount_atomic(FimoAtomicRefCount *count) {
     FIMO_DEBUG_ASSERT(count)
     FimoUSize current = atomic_load_explicit(&count->weak_refs, memory_order_relaxed);
     for (;;) {

--- a/ffi_library/fimo_std/src/time.c
+++ b/ffi_library/fimo_std/src/time.c
@@ -144,7 +144,7 @@ FimoU64 fimo_duration_as_nanos(const FimoDuration *duration, FimoU32 *high) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_duration_add(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out) {
+FimoResult fimo_duration_add(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out) {
     FIMO_DEBUG_ASSERT(lhs && rhs && out)
     FimoIntOptionU64 secs_check = fimo_u64_checked_add(lhs->secs, rhs->secs);
     if (!secs_check.has_value) {
@@ -172,8 +172,9 @@ FIMO_MUST_USE
 FimoDuration fimo_duration_saturating_add(const FimoDuration *lhs, const FimoDuration *rhs) {
     FIMO_DEBUG_ASSERT(lhs && rhs)
     FimoDuration result;
-    const FimoError error = fimo_duration_add(lhs, rhs, &result);
-    if (FIMO_IS_ERROR(error)) {
+    const FimoResult error = fimo_duration_add(lhs, rhs, &result);
+    if (FIMO_RESULT_IS_ERROR(error)) {
+        fimo_result_release(error);
         return FIMO_DURATION_MAX;
     }
     return result;
@@ -181,7 +182,7 @@ FimoDuration fimo_duration_saturating_add(const FimoDuration *lhs, const FimoDur
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_duration_sub(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out) {
+FimoResult fimo_duration_sub(const FimoDuration *lhs, const FimoDuration *rhs, FimoDuration *out) {
     FIMO_DEBUG_ASSERT(lhs && rhs && out)
     if (lhs->secs < rhs->secs) {
         return FIMO_ERANGE;
@@ -211,8 +212,9 @@ FIMO_MUST_USE
 FimoDuration fimo_duration_saturating_sub(const FimoDuration *lhs, const FimoDuration *rhs) {
     FIMO_DEBUG_ASSERT(lhs && rhs)
     FimoDuration result;
-    const FimoError error = fimo_duration_sub(lhs, rhs, &result);
-    if (FIMO_IS_ERROR(error)) {
+    const FimoResult error = fimo_duration_sub(lhs, rhs, &result);
+    if (FIMO_RESULT_IS_ERROR(error)) {
+        fimo_result_release(error);
         return FIMO_DURATION_ZERO;
     }
     return result;
@@ -241,7 +243,7 @@ FimoTime fimo_time_now(void) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_elapsed(const FimoTime *time_point, FimoDuration *elapsed) {
+FimoResult fimo_time_elapsed(const FimoTime *time_point, FimoDuration *elapsed) {
     FIMO_DEBUG_ASSERT(time_point && elapsed)
     const FimoTime now = fimo_time_now();
     return fimo_time_duration_since(&now, time_point, elapsed);
@@ -249,8 +251,8 @@ FimoError fimo_time_elapsed(const FimoTime *time_point, FimoDuration *elapsed) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_duration_since(const FimoTime *time_point, const FimoTime *earlier_time_point,
-                                   FimoDuration *duration) {
+FimoResult fimo_time_duration_since(const FimoTime *time_point, const FimoTime *earlier_time_point,
+                                    FimoDuration *duration) {
     FIMO_DEBUG_ASSERT(time_point && earlier_time_point && duration)
     if (time_point->secs < earlier_time_point->secs) {
         return FIMO_ERANGE;
@@ -277,7 +279,7 @@ FimoError fimo_time_duration_since(const FimoTime *time_point, const FimoTime *e
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_add(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out) {
+FimoResult fimo_time_add(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out) {
     FIMO_DEBUG_ASSERT(time_point && duration && out)
     FimoIntOptionU64 secs_check = fimo_u64_checked_add(time_point->secs, duration->secs);
     if (!secs_check.has_value) {
@@ -305,8 +307,9 @@ FIMO_MUST_USE
 FimoTime fimo_time_saturating_add(const FimoTime *time_point, const FimoDuration *duration) {
     FIMO_DEBUG_ASSERT(time_point && duration)
     FimoTime result;
-    const FimoError error = fimo_time_add(time_point, duration, &result);
-    if (FIMO_IS_ERROR(error)) {
+    const FimoResult error = fimo_time_add(time_point, duration, &result);
+    if (FIMO_RESULT_IS_ERROR(error)) {
+        fimo_result_release(error);
         return FIMO_TIME_MAX;
     }
     return result;
@@ -314,7 +317,7 @@ FimoTime fimo_time_saturating_add(const FimoTime *time_point, const FimoDuration
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_time_sub(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out) {
+FimoResult fimo_time_sub(const FimoTime *time_point, const FimoDuration *duration, FimoTime *out) {
     FIMO_DEBUG_ASSERT(time_point && duration && out)
     if (time_point->secs < duration->secs) {
         return FIMO_ERANGE;
@@ -344,8 +347,9 @@ FIMO_MUST_USE
 FimoTime fimo_time_saturating_sub(const FimoTime *time_point, const FimoDuration *duration) {
     FIMO_DEBUG_ASSERT(time_point && duration)
     FimoTime result;
-    const FimoError error = fimo_time_sub(time_point, duration, &result);
-    if (FIMO_IS_ERROR(error)) {
+    const FimoResult error = fimo_time_sub(time_point, duration, &result);
+    if (FIMO_RESULT_IS_ERROR(error)) {
+        fimo_result_release(error);
         return FIMO_UNIX_EPOCH;
     }
     return result;

--- a/ffi_library/fimo_std/src/tracing.c
+++ b/ffi_library/fimo_std/src/tracing.c
@@ -29,43 +29,43 @@ const FimoTracingSubscriber FIMO_TRACING_DEFAULT_SUBSCRIBER = {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_create(const FimoContext context, FimoTracingCallStack **call_stack) {
+FimoResult fimo_tracing_call_stack_create(const FimoContext context, FimoTracingCallStack **call_stack) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.call_stack_create(context.data, call_stack);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_destroy(const FimoContext context, FimoTracingCallStack *call_stack) {
+FimoResult fimo_tracing_call_stack_destroy(const FimoContext context, FimoTracingCallStack *call_stack) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.call_stack_destroy(context.data, call_stack);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_switch(const FimoContext context, FimoTracingCallStack *call_stack,
-                                         FimoTracingCallStack **old) {
+FimoResult fimo_tracing_call_stack_switch(const FimoContext context, FimoTracingCallStack *call_stack,
+                                          FimoTracingCallStack **old) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.call_stack_switch(context.data, call_stack, old);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_unblock(const FimoContext context, FimoTracingCallStack *call_stack) {
+FimoResult fimo_tracing_call_stack_unblock(const FimoContext context, FimoTracingCallStack *call_stack) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.call_stack_unblock(context.data, call_stack);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_suspend_current(const FimoContext context, const bool block) {
+FimoResult fimo_tracing_call_stack_suspend_current(const FimoContext context, const bool block) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.call_stack_suspend_current(context.data, block);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_call_stack_resume_current(const FimoContext context) {
+FimoResult fimo_tracing_call_stack_resume_current(const FimoContext context) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.call_stack_resume_current(context.data);
 }
@@ -73,27 +73,27 @@ FimoError fimo_tracing_call_stack_resume_current(const FimoContext context) {
 FIMO_EXPORT
 FIMO_PRINT_F_FORMAT_ATTR(4, 5)
 FIMO_MUST_USE
-FimoError fimo_tracing_span_create_fmt(const FimoContext context, const FimoTracingSpanDesc *span_desc,
-                                       FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...) {
+FimoResult fimo_tracing_span_create_fmt(const FimoContext context, const FimoTracingSpanDesc *span_desc,
+                                        FimoTracingSpan **span, FIMO_PRINT_F_FORMAT const char *format, ...) {
     va_list vlist;
     va_start(vlist, format);
     FimoImplTracingFmtArgs args = {.format = format, .vlist = &vlist};
-    FimoError result = fimo_tracing_span_create_custom(context, span_desc, span, fimo_impl_tracing_fmt, &args);
+    FimoResult result = fimo_tracing_span_create_custom(context, span_desc, span, fimo_impl_tracing_fmt, &args);
     va_end(vlist);
     return result;
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_span_create_custom(const FimoContext context, const FimoTracingSpanDesc *span_desc,
-                                          FimoTracingSpan **span, const FimoTracingFormat format, const void *data) {
+FimoResult fimo_tracing_span_create_custom(const FimoContext context, const FimoTracingSpanDesc *span_desc,
+                                           FimoTracingSpan **span, const FimoTracingFormat format, const void *data) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.span_create(context.data, span_desc, span, format, data);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_span_destroy(const FimoContext context, FimoTracingSpan *span) {
+FimoResult fimo_tracing_span_destroy(const FimoContext context, FimoTracingSpan *span) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.span_destroy(context.data, span);
 }
@@ -101,20 +101,20 @@ FimoError fimo_tracing_span_destroy(const FimoContext context, FimoTracingSpan *
 FIMO_EXPORT
 FIMO_PRINT_F_FORMAT_ATTR(3, 4)
 FIMO_MUST_USE
-FimoError fimo_tracing_event_emit_fmt(const FimoContext context, const FimoTracingEvent *event,
-                                      FIMO_PRINT_F_FORMAT const char *format, ...) {
+FimoResult fimo_tracing_event_emit_fmt(const FimoContext context, const FimoTracingEvent *event,
+                                       FIMO_PRINT_F_FORMAT const char *format, ...) {
     va_list vlist;
     va_start(vlist, format);
     FimoImplTracingFmtArgs args = {.format = format, .vlist = &vlist};
-    FimoError result = fimo_tracing_event_emit_custom(context, event, fimo_impl_tracing_fmt, &args);
+    FimoResult result = fimo_tracing_event_emit_custom(context, event, fimo_impl_tracing_fmt, &args);
     va_end(vlist);
     return result;
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_event_emit_custom(const FimoContext context, const FimoTracingEvent *event,
-                                         const FimoTracingFormat format, const void *data) {
+FimoResult fimo_tracing_event_emit_custom(const FimoContext context, const FimoTracingEvent *event,
+                                          const FimoTracingFormat format, const void *data) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.event_emit(context.data, event, format, data);
 }
@@ -128,21 +128,21 @@ bool fimo_tracing_is_enabled(const FimoContext context) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_register_thread(const FimoContext context) {
+FimoResult fimo_tracing_register_thread(const FimoContext context) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.register_thread(context.data);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_unregister_thread(const FimoContext context) {
+FimoResult fimo_tracing_unregister_thread(const FimoContext context) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.unregister_thread(context.data);
 }
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_tracing_flush(const FimoContext context) {
+FimoResult fimo_tracing_flush(const FimoContext context) {
     const FimoContextVTable *vtable = context.vtable;
     return vtable->tracing_v0.flush(context.data);
 }

--- a/ffi_library/fimo_std/src/version.c
+++ b/ffi_library/fimo_std/src/version.c
@@ -12,7 +12,7 @@
 #include <fimo_std/error.h>
 #include <fimo_std/utils.h>
 
-static FimoError parse_str_u32(const char **str, const size_t str_len, FimoU32 *num) {
+static FimoResult parse_str_u32(const char **str, const size_t str_len, FimoU32 *num) {
     // 2^32 requires up a maximum of 10 digits, with 1 extra for
     // the 0 termination and another one to detect out of range
     // numbers.
@@ -42,7 +42,7 @@ static FimoError parse_str_u32(const char **str, const size_t str_len, FimoU32 *
     return FIMO_EOK;
 }
 
-static FimoError parse_str_u64(const char **str, const size_t str_len, FimoU64 *num) {
+static FimoResult parse_str_u64(const char **str, const size_t str_len, FimoU64 *num) {
     // 2^64 requires up a maximum of 20 digits, with 1 extra for
     // the 0 termination and another one to detect out of range
     // numbers.
@@ -74,7 +74,7 @@ static FimoError parse_str_u64(const char **str, const size_t str_len, FimoU64 *
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_version_parse_str(const char *str, const size_t str_len, FimoVersion *version) {
+FimoResult fimo_version_parse_str(const char *str, const size_t str_len, FimoVersion *version) {
     if (str == NULL || str_len == 0 || isspace(*str) || version == NULL) {
         return FIMO_EINVAL;
     }
@@ -82,8 +82,8 @@ FimoError fimo_version_parse_str(const char *str, const size_t str_len, FimoVers
     const char *current = str;
     const char *str_end = str + str_len;
 
-    FimoError error = parse_str_u32(&current, str_end - current, &version->major);
-    if (FIMO_IS_ERROR(error)) {
+    FimoResult error = parse_str_u32(&current, str_end - current, &version->major);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
     if (current == str_end || *current != '.') {
@@ -92,7 +92,7 @@ FimoError fimo_version_parse_str(const char *str, const size_t str_len, FimoVers
 
     current++;
     error = parse_str_u32(&current, str_end - current, &version->minor);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
     if (current == str_end || *current != '.') {
@@ -101,7 +101,7 @@ FimoError fimo_version_parse_str(const char *str, const size_t str_len, FimoVers
 
     current++;
     error = parse_str_u32(&current, str_end - current, &version->patch);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
@@ -148,7 +148,7 @@ size_t fimo_version_str_len_full(const FimoVersion *version) {
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_version_write_str(const FimoVersion *version, char *str, const size_t str_len, size_t *written) {
+FimoResult fimo_version_write_str(const FimoVersion *version, char *str, const size_t str_len, size_t *written) {
     if (version == NULL || str == NULL || str_len == 0) {
         return FIMO_EINVAL;
     }
@@ -182,7 +182,7 @@ FimoError fimo_version_write_str(const FimoVersion *version, char *str, const si
 
 FIMO_EXPORT
 FIMO_MUST_USE
-FimoError fimo_version_write_str_long(const FimoVersion *version, char *str, const size_t str_len, size_t *written) {
+FimoResult fimo_version_write_str_long(const FimoVersion *version, char *str, const size_t str_len, size_t *written) {
     if (version == NULL || str == NULL || str_len == 0) {
         return FIMO_EINVAL;
     }

--- a/ffi_library/fimo_std/tests/context.cpp
+++ b/ffi_library/fimo_std/tests/context.cpp
@@ -4,11 +4,11 @@
 
 TEST_CASE("Context initalization", "[context]") {
     FimoContext ctx;
-    FimoError error = fimo_context_init(nullptr, &ctx);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_context_init(nullptr, &ctx);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_context_check_version(ctx);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     fimo_context_acquire(ctx);
     fimo_context_release(ctx);

--- a/ffi_library/fimo_std/tests/graph.cpp
+++ b/ffi_library/fimo_std/tests/graph.cpp
@@ -8,80 +8,83 @@ TEST_CASE("Graph initialization", "[graph]") {
 
     // Invalid node size/destructor pair
     FimoGraph *graph;
-    FimoError error = fimo_graph_new(0, 0, dummy_cleanup, nullptr, &graph);
-    REQUIRE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_graph_new(0, 0, dummy_cleanup, nullptr, &graph);
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
 
     // Invalid edge size/destructor pair
     error = fimo_graph_new(0, 0, nullptr, dummy_cleanup, &graph);
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
 
     error = fimo_graph_new(0, 0, nullptr, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(sizeof(int), 0, nullptr, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(sizeof(int), 0, dummy_cleanup, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(0, sizeof(int), nullptr, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(0, sizeof(int), nullptr, dummy_cleanup, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(sizeof(int), sizeof(int), nullptr, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(sizeof(int), sizeof(int), dummy_cleanup, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(sizeof(int), sizeof(int), nullptr, dummy_cleanup, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 
     error = fimo_graph_new(sizeof(int), sizeof(int), dummy_cleanup, dummy_cleanup, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_graph_free(graph);
 }
 
 TEST_CASE("Graph with zero-sized nodes", "[graph]") {
     FimoGraph *graph;
-    FimoError error = fimo_graph_new(0, 0, nullptr, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_graph_new(0, 0, nullptr, nullptr, &graph);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_node_count(graph) == 0);
 
     // Data when the node expects no data.
     FimoU64 node_a;
     int tmp = 5;
     error = fimo_graph_add_node(graph, &tmp, &node_a);
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
 
     error = fimo_graph_add_node(graph, nullptr, &node_a);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_node_count(graph) == 1);
 
     const int *node_a_data = nullptr;
     error = fimo_graph_node_data(graph, node_a, reinterpret_cast<const void **>(&node_a_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(node_a_data == nullptr);
 
     FimoU64 node_b;
     error = fimo_graph_add_node(graph, nullptr, &node_b);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_node_count(graph) == 2);
     REQUIRE_FALSE(node_a == node_b);
 
     const int *node_b_data = nullptr;
     error = fimo_graph_node_data(graph, node_b, reinterpret_cast<const void **>(&node_b_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(node_b_data == nullptr);
 
     fimo_graph_free(graph);
@@ -91,36 +94,37 @@ TEST_CASE("Graph with sized nodes", "[graph]") {
     auto dummy_cleanup = [](void *data) { (void)data; };
 
     FimoGraph *graph;
-    FimoError error = fimo_graph_new(sizeof(int), 0, dummy_cleanup, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_graph_new(sizeof(int), 0, dummy_cleanup, nullptr, &graph);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_node_count(graph) == 0);
 
     // Empty data when the node expects some data.
     FimoU64 node_a;
     error = fimo_graph_add_node(graph, nullptr, &node_a);
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
 
     int tmp = 5;
     error = fimo_graph_add_node(graph, &tmp, &node_a);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_node_count(graph) == 1);
 
     const int *node_a_data = nullptr;
     error = fimo_graph_node_data(graph, node_a, reinterpret_cast<const void **>(&node_a_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(node_a_data != nullptr);
     REQUIRE(*node_a_data == 5);
 
     FimoU64 node_b;
     tmp = 10;
     error = fimo_graph_add_node(graph, &tmp, &node_b);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_node_count(graph) == 2);
     REQUIRE_FALSE(node_a == node_b);
 
     const int *node_b_data = nullptr;
     error = fimo_graph_node_data(graph, node_b, reinterpret_cast<const void **>(&node_b_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(node_b_data != nullptr);
     REQUIRE(*node_b_data == 10);
 
@@ -129,60 +133,61 @@ TEST_CASE("Graph with sized nodes", "[graph]") {
 
 TEST_CASE("Graph with zero-sized edges", "[graph]") {
     FimoGraph *graph;
-    FimoError error = fimo_graph_new(0, 0, nullptr, nullptr, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_graph_new(0, 0, nullptr, nullptr, &graph);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_edge_count(graph) == 0);
 
     FimoU64 node_a;
     error = fimo_graph_add_node(graph, nullptr, &node_a);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     FimoU64 node_b;
     error = fimo_graph_add_node(graph, nullptr, &node_b);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     FimoU64 node_c;
     error = fimo_graph_add_node(graph, nullptr, &node_c);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     int tmp = 0;
     void *old_data = nullptr;
 
     FimoU64 edge_ab;
     error = fimo_graph_add_edge(graph, node_a, node_b, &tmp, &old_data, &edge_ab);
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
 
     error = fimo_graph_add_edge(graph, node_a, node_b, nullptr, &old_data, &edge_ab);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(old_data == nullptr);
     REQUIRE(fimo_graph_edge_count(graph) == 1);
 
     const int *edge_ab_data = nullptr;
     error = fimo_graph_edge_data(graph, edge_ab, reinterpret_cast<const void **>(&edge_ab_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(edge_ab_data == nullptr);
 
     FimoU64 edge_ab_new;
     error = fimo_graph_add_edge(graph, node_a, node_b, nullptr, &old_data, &edge_ab_new);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(old_data == nullptr);
     REQUIRE(fimo_graph_edge_count(graph) == 1);
     REQUIRE(edge_ab == edge_ab_new);
 
     error = fimo_graph_edge_data(graph, edge_ab, reinterpret_cast<const void **>(&edge_ab_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(edge_ab_data == nullptr);
 
     FimoU64 edge_bc;
     error = fimo_graph_add_edge(graph, node_b, node_c, nullptr, &old_data, &edge_bc);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(old_data == nullptr);
     REQUIRE(fimo_graph_edge_count(graph) == 2);
     REQUIRE_FALSE(edge_ab == edge_bc);
 
     const int *edge_bc_data = nullptr;
     error = fimo_graph_edge_data(graph, edge_bc, reinterpret_cast<const void **>(&edge_bc_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(edge_bc_data == nullptr);
 
     fimo_graph_free(graph);
@@ -192,44 +197,45 @@ TEST_CASE("Graph with sized edged", "[graph]") {
     auto dummy_cleanup = [](void *data) { (void)data; };
 
     FimoGraph *graph;
-    FimoError error = fimo_graph_new(0, sizeof(int), nullptr, dummy_cleanup, &graph);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_graph_new(0, sizeof(int), nullptr, dummy_cleanup, &graph);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(fimo_graph_edge_count(graph) == 0);
 
     FimoU64 node_a;
     error = fimo_graph_add_node(graph, nullptr, &node_a);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     FimoU64 node_b;
     error = fimo_graph_add_node(graph, nullptr, &node_b);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     FimoU64 node_c;
     error = fimo_graph_add_node(graph, nullptr, &node_c);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     void *old_data = nullptr;
 
     FimoU64 edge_ab;
     error = fimo_graph_add_edge(graph, node_a, node_b, nullptr, &old_data, &edge_ab);
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
 
     int tmp = 0;
     error = fimo_graph_add_edge(graph, node_a, node_b, &tmp, &old_data, &edge_ab);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(old_data == nullptr);
     REQUIRE(fimo_graph_edge_count(graph) == 1);
 
     const int *edge_ab_data = nullptr;
     error = fimo_graph_edge_data(graph, edge_ab, reinterpret_cast<const void **>(&edge_ab_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(edge_ab_data != nullptr);
     REQUIRE(*edge_ab_data == 0);
 
     tmp = 1;
     FimoU64 edge_ab_new;
     error = fimo_graph_add_edge(graph, node_a, node_b, &tmp, &old_data, &edge_ab_new);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(old_data != nullptr);
     REQUIRE(fimo_graph_edge_count(graph) == 1);
     REQUIRE(edge_ab == edge_ab_new);
@@ -237,21 +243,21 @@ TEST_CASE("Graph with sized edged", "[graph]") {
     fimo_free_sized(old_data, sizeof(int));
 
     error = fimo_graph_edge_data(graph, edge_ab, reinterpret_cast<const void **>(&edge_ab_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(edge_ab_data != nullptr);
     REQUIRE(*edge_ab_data == 1);
 
     tmp = 2;
     FimoU64 edge_bc;
     error = fimo_graph_add_edge(graph, node_b, node_c, &tmp, &old_data, &edge_bc);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(old_data == nullptr);
     REQUIRE(fimo_graph_edge_count(graph) == 2);
     REQUIRE_FALSE(edge_ab == edge_bc);
 
     const int *edge_bc_data = nullptr;
     error = fimo_graph_edge_data(graph, edge_bc, reinterpret_cast<const void **>(&edge_bc_data));
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE(edge_bc_data != nullptr);
     REQUIRE(*edge_bc_data == 2);
 

--- a/ffi_library/fimo_std/tests/memory.cpp
+++ b/ffi_library/fimo_std/tests/memory.cpp
@@ -3,18 +3,18 @@
 #include <fimo_std/memory.h>
 
 TEST_CASE("Allocate memory", "[memory]") {
-    FimoError error;
+    FimoResult error;
 
     SECTION("zero size results in a null pointer") {
         void *buffer = fimo_malloc(0, &error);
         REQUIRE(buffer == nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     }
 
     SECTION("allocation is properly aligned") {
         void *buffer = fimo_malloc(sizeof(long long), &error);
         REQUIRE(buffer != nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
         REQUIRE(reinterpret_cast<FimoUIntPtr>(buffer) % FIMO_MALLOC_ALIGNMENT == 0);
         fimo_free(buffer);
     }
@@ -22,7 +22,7 @@ TEST_CASE("Allocate memory", "[memory]") {
     SECTION("allocation is properly aligned and sized") {
         FimoMallocBuffer buffer = fimo_malloc_sized(1339, &error);
         REQUIRE(buffer.ptr != nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
         REQUIRE(buffer.buff_size >= 1339);
         REQUIRE(reinterpret_cast<FimoUIntPtr>(buffer.ptr) % FIMO_MALLOC_ALIGNMENT == 0);
         fimo_free(buffer.ptr);
@@ -30,18 +30,18 @@ TEST_CASE("Allocate memory", "[memory]") {
 }
 
 TEST_CASE("Allocate zeroed memory", "[memory]") {
-    FimoError error;
+    FimoResult error;
 
     SECTION("zero size results in a null pointer") {
         void *buffer = fimo_calloc(0, &error);
         REQUIRE(buffer == nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     }
 
     SECTION("allocation is properly aligned") {
         long long *buffer = static_cast<long long *>(fimo_calloc(10 * sizeof(long long), &error));
         REQUIRE(buffer != nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
         REQUIRE(reinterpret_cast<FimoUIntPtr>(buffer) % FIMO_MALLOC_ALIGNMENT == 0);
         for (FimoUSize i = 0; i < 10; i++) {
             REQUIRE(buffer[i] == 0);
@@ -52,7 +52,7 @@ TEST_CASE("Allocate zeroed memory", "[memory]") {
     SECTION("allocation is properly aligned and sized") {
         FimoMallocBuffer buffer = fimo_calloc_sized(1339, &error);
         REQUIRE(buffer.ptr != nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
         REQUIRE(buffer.buff_size >= 1339);
         REQUIRE(reinterpret_cast<FimoUIntPtr>(buffer.ptr) % FIMO_MALLOC_ALIGNMENT == 0);
         for (FimoUSize i = 0; i < buffer.buff_size; i++) {
@@ -63,30 +63,32 @@ TEST_CASE("Allocate zeroed memory", "[memory]") {
 }
 
 TEST_CASE("Allocate aligned memory", "[memory]") {
-    FimoError error;
+    FimoResult error;
 
     SECTION("alignment must not be zero") {
         void *buffer = fimo_aligned_alloc(0, 10, &error);
         REQUIRE(buffer == nullptr);
-        REQUIRE(FIMO_IS_ERROR(error));
+        REQUIRE(FIMO_RESULT_IS_ERROR(error));
+        fimo_result_release(error);
     }
 
     SECTION("alignment must be a power of two") {
         void *buffer = fimo_aligned_alloc(17, 10, &error);
         REQUIRE(buffer == nullptr);
-        REQUIRE(FIMO_IS_ERROR(error));
+        REQUIRE(FIMO_RESULT_IS_ERROR(error));
+        fimo_result_release(error);
     }
 
     SECTION("zero size results in a null pointer") {
         void *buffer = fimo_aligned_alloc(256, 0, &error);
         REQUIRE(buffer == nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     }
 
     SECTION("allocation is properly aligned") {
         void *buffer = static_cast<long long *>(fimo_aligned_alloc(256, sizeof(long long), &error));
         REQUIRE(buffer != nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
         REQUIRE(reinterpret_cast<FimoUIntPtr>(buffer) % 256 == 0);
         fimo_free_aligned_sized(buffer, 256, sizeof(long long));
     }
@@ -94,7 +96,7 @@ TEST_CASE("Allocate aligned memory", "[memory]") {
     SECTION("allocation is properly aligned and sized") {
         FimoMallocBuffer buffer = fimo_aligned_alloc_sized(256, 1339, &error);
         REQUIRE(buffer.ptr != nullptr);
-        REQUIRE_FALSE(FIMO_IS_ERROR(error));
+        REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
         REQUIRE(buffer.buff_size >= 1339);
         REQUIRE(reinterpret_cast<FimoUIntPtr>(buffer.ptr) % 256 == 0);
         fimo_free_aligned_sized(buffer.ptr, 256, buffer.buff_size);

--- a/ffi_library/fimo_std/tests/module_subsystem.cpp
+++ b/ffi_library/fimo_std/tests/module_subsystem.cpp
@@ -68,7 +68,7 @@ FIMO_MODULE_SYMBOL_TABLE(
             FIMO_MODULE_SYMBOL_TABLE_VAR(b_0, int);
             FIMO_MODULE_SYMBOL_TABLE_VAR(b_1, int);
         })
-static FimoError c_constructor(const FimoModule *module, FimoModuleLoadingSet *set, void **data) {
+static FimoResult c_constructor(const FimoModule *module, FimoModuleLoadingSet *set, void **data) {
     REQUIRE(module != nullptr);
     REQUIRE(set != nullptr);
     REQUIRE(data != nullptr);
@@ -83,59 +83,59 @@ static FimoError c_constructor(const FimoModule *module, FimoModuleLoadingSet *s
     const CParamTable *params = static_cast<const CParamTable *>(module->parameters);
     FimoU32 value;
     FimoModuleParamType type;
-    FimoError error = fimo_module_param_get_private(module, &value, &type, params->pub_pub);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_module_param_get_private(module, &value, &type, params->pub_pub);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 0 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->pub_pub);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->pub_dep);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 1 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->pub_dep);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->pub_pri);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 2 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->pub_pri);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->dep_pub);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 3 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->dep_pub);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->dep_dep);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 4 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->dep_dep);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->dep_pri);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 5 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->dep_pri);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->pri_pub);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 6 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->pri_pub);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->pri_dep);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 7 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->pri_dep);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_private(module, &value, &type, params->pri_pri);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 8 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_private(module, &value, type, params->pri_pri);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     const CResourceTable *resources = static_cast<const CResourceTable *>(module->resources);
     (void)resources;
@@ -184,70 +184,74 @@ TEST_CASE("Load modules", "[modules]") {
     const FimoBaseStructIn *options[] = {reinterpret_cast<FimoBaseStructIn *>(&config), nullptr};
 
     FimoContext context;
-    FimoError error = fimo_context_init(options, &context);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_context_init(options, &context);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_tracing_register_thread(context);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     FimoModuleLoadingSet *set;
     error = fimo_module_set_new(context, &set);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_set_append_modules(context, set, nullptr, modules_filter, nullptr);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_set_finish(context, set);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     const FimoModule *pseudo_module;
     error = fimo_module_pseudo_module_new(context, &pseudo_module);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_context_release(context);
 
     FimoU32 value;
     FimoModuleParamType type;
     error = fimo_module_param_get_public(pseudo_module->context, &value, &type, "c", "pub_pub");
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     REQUIRE((value == 0 && type == FIMO_MODULE_PARAM_TYPE_U32));
     error = fimo_module_param_set_public(pseudo_module->context, &value, type, "c", "pub_pub");
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_public(pseudo_module->context, &value, &type, "c", "dep_pub");
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
     error = fimo_module_param_get_public(pseudo_module->context, &value, &type, "c", "pri_pub");
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
     error = fimo_module_param_set_public(pseudo_module->context, &value, type, "c", "pub_dep");
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
     error = fimo_module_param_set_public(pseudo_module->context, &value, type, "c", "pub_pri");
-    REQUIRE(FIMO_IS_ERROR(error));
+    REQUIRE(FIMO_RESULT_IS_ERROR(error));
+    fimo_result_release(error);
 
     const FimoModuleInfo *a_info;
     error = fimo_module_find_by_name(pseudo_module->context, "a", &a_info);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     const FimoModuleInfo *c_info;
     error = fimo_module_find_by_name(pseudo_module->context, "c", &c_info);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_acquire_dependency(pseudo_module, a_info);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     error = fimo_module_acquire_dependency(pseudo_module, c_info);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_param_get_dependency(pseudo_module, &value, &type, "c", "dep_pub");
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     error = fimo_module_param_set_dependency(pseudo_module, &value, type, "c", "pub_dep");
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     const FimoModuleRawSymbol *a_export_0_symbol;
     error = fimo_module_load_symbol(pseudo_module, "a_export_0", "", FIMO_VERSION(0, 1, 0), &a_export_0_symbol);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     const int *a_export_0_symbol_ptr = static_cast<const int *>(FIMO_MODULE_SYMBOL_LOCK(a_export_0_symbol));
     REQUIRE(*a_export_0_symbol_ptr == a_export_0);
     FIMO_MODULE_SYMBOL_RELEASE(a_export_0_symbol);
 
     error = fimo_module_pseudo_module_destroy(pseudo_module, &context);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     FIMO_MODULE_INFO_RELEASE(a_info);
     FIMO_MODULE_INFO_RELEASE(c_info);

--- a/ffi_library/fimo_tasks/include/fimo_tasks/tasks.h
+++ b/ffi_library/fimo_tasks/include/fimo_tasks/tasks.h
@@ -269,10 +269,10 @@ typedef struct FiTasksWorkerGroupVTableV0 {
     bool (*is_open)(void *);
     bool (*is_worker)(void *);
     const char *(*name)(void *);
-    FimoError (*request_close)(void *);
-    FimoError (*workers)(void *, FimoUSize **, FimoUSize *);
-    FimoError (*stack_sizes)(void *, FimoUSize **, FimoUSize *);
-    FimoError (*enqueue_buffer)(void *, FiTasksCommandBuffer *, bool, FiTasksCommandBufferHandle *);
+    FimoResult (*request_close)(void *);
+    FimoResult (*workers)(void *, FimoUSize **, FimoUSize *);
+    FimoResult (*stack_sizes)(void *, FimoUSize **, FimoUSize *);
+    FimoResult (*enqueue_buffer)(void *, FiTasksCommandBuffer *, bool, FiTasksCommandBufferHandle *);
 } FiTasksWorkerGroupVTableV0;
 
 struct FiTasksWorkerGroupVTable {
@@ -285,8 +285,8 @@ struct FiTasksWorkerGroupVTable {
 typedef struct FiTasksCommandBufferHandleVTableV0 {
     void (*acquire)(void *);
     void (*release)(void *);
-    FimoError (*worker_group)(void *, FiTasksWorkerGroup *);
-    FimoError (*wait_on)(void *, bool *);
+    FimoResult (*worker_group)(void *, FiTasksWorkerGroup *);
+    FimoResult (*wait_on)(void *, bool *);
 } FiTasksCommandBufferHandleVTableV0;
 
 /**
@@ -596,29 +596,29 @@ typedef enum FiTasksRequeueOp {
  */
 typedef struct FiTasksVTableV0 {
     bool (*is_worker)(void *);
-    FimoError (*task_id)(void *, FimoUSize *);
-    FimoError (*worker_id)(void *, FimoUSize *);
-    FimoError (*worker_group)(void *, FiTasksWorkerGroup *);
-    FimoError (*worker_group_by_id)(void *, FimoUSize, FiTasksWorkerGroup *);
-    FimoError (*query_worker_groups)(void *, FiTasksWorkerGroupQuery **);
-    FimoError (*release_worker_group_query)(void *, FiTasksWorkerGroupQuery *);
-    FimoError (*create_worker_group)(void *, FiTasksWorkerGroupConfig, FiTasksWorkerGroup *);
-    FimoError (*yield)(void *);
-    FimoError (*abort)(void *, void *);
-    FimoError (*sleep)(void *, FimoDuration);
-    FimoError (*tss_set)(void *, FiTasksTssKey, void *, FiTasksTssDtor);
-    FimoError (*tss_get)(void *, FiTasksTssKey, void **);
-    FimoError (*tss_clear)(void *, FiTasksTssKey);
-    FimoError (*park_conditionally)(void *, const void *, bool (*)(void *), void *, void (*)(void *), void *,
+    FimoResult (*task_id)(void *, FimoUSize *);
+    FimoResult (*worker_id)(void *, FimoUSize *);
+    FimoResult (*worker_group)(void *, FiTasksWorkerGroup *);
+    FimoResult (*worker_group_by_id)(void *, FimoUSize, FiTasksWorkerGroup *);
+    FimoResult (*query_worker_groups)(void *, FiTasksWorkerGroupQuery **);
+    FimoResult (*release_worker_group_query)(void *, FiTasksWorkerGroupQuery *);
+    FimoResult (*create_worker_group)(void *, FiTasksWorkerGroupConfig, FiTasksWorkerGroup *);
+    FimoResult (*yield)(void *);
+    FimoResult (*abort)(void *, void *);
+    FimoResult (*sleep)(void *, FimoDuration);
+    FimoResult (*tss_set)(void *, FiTasksTssKey, void *, FiTasksTssDtor);
+    FimoResult (*tss_get)(void *, FiTasksTssKey, void **);
+    FimoResult (*tss_clear)(void *, FiTasksTssKey);
+    FimoResult (*park_conditionally)(void *, const void *, bool (*)(void *), void *, void (*)(void *), void *,
                                     void (*)(void *, const void *, bool), void *, const void *, const FimoDuration *,
                                     FiTasksParkResult *);
-    FimoError (*unpark_one)(void *, const void *, const void *(*)(void *, FiTasksUnparkResult), void *,
+    FimoResult (*unpark_one)(void *, const void *, const void *(*)(void *, FiTasksUnparkResult), void *,
                             FiTasksUnparkResult *);
-    FimoError (*unpark_all)(void *, const void *, const void *, FimoUSize *);
-    FimoError (*unpark_requeue)(void *, const void *, const void *, FiTasksRequeueOp (*)(void *), void *,
+    FimoResult (*unpark_all)(void *, const void *, const void *, FimoUSize *);
+    FimoResult (*unpark_requeue)(void *, const void *, const void *, FiTasksRequeueOp (*)(void *), void *,
                                 const void *(*)(void *, FiTasksRequeueOp, FiTasksUnparkResult), void *,
                                 FiTasksUnparkResult *);
-    FimoError (*unpark_filter)(void *, const void *, FiTasksUnparkFilterOp (*)(void *, const void *), void *,
+    FimoResult (*unpark_filter)(void *, const void *, FiTasksUnparkFilterOp (*)(void *, const void *), void *,
                                const void *(*)(void *, FiTasksUnparkResult), void *, FiTasksUnparkResult *);
 } FiTasksVTableV0;
 
@@ -709,7 +709,7 @@ static FIMO_INLINE_ALWAYS const char *fi_tasks_worker_group_name(FiTasksWorkerGr
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_worker_group_request_close(FiTasksWorkerGroup grp) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_worker_group_request_close(FiTasksWorkerGroup grp) {
     return grp.vtable->v0.request_close(grp.data);
 }
 
@@ -729,7 +729,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_worker_group_request_close(FiTasksW
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_worker_group_workers(FiTasksWorkerGroup grp, FimoUSize **workers,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_worker_group_workers(FiTasksWorkerGroup grp, FimoUSize **workers,
                                                                   FimoUSize *count) {
     return grp.vtable->v0.workers(grp.data, workers, count);
 }
@@ -753,7 +753,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_worker_group_workers(FiTasksWorkerG
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_worker_group_stack_sizes(FiTasksWorkerGroup grp, FimoUSize **stack_sizes,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_worker_group_stack_sizes(FiTasksWorkerGroup grp, FimoUSize **stack_sizes,
                                                                       FimoUSize *count) {
     return grp.vtable->v0.stack_sizes(grp.data, stack_sizes, count);
 }
@@ -777,7 +777,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_worker_group_stack_sizes(FiTasksWor
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_worker_group_enqueue_buffer(FiTasksWorkerGroup grp,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_worker_group_enqueue_buffer(FiTasksWorkerGroup grp,
                                                                          FiTasksCommandBuffer *buffer, bool detached,
                                                                          FiTasksCommandBufferHandle *handle) {
     return grp.vtable->v0.enqueue_buffer(grp.data, buffer, detached, handle);
@@ -810,7 +810,7 @@ static FIMO_INLINE_ALWAYS void fi_tasks_command_buffer_handle_release(FiTasksCom
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_command_buffer_worker_group(FiTasksCommandBufferHandle handle,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_command_buffer_worker_group(FiTasksCommandBufferHandle handle,
                                                                          FiTasksWorkerGroup *grp) {
     return handle.vtable->v0.worker_group(handle.data, grp);
 }
@@ -832,7 +832,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_command_buffer_worker_group(FiTasks
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_command_buffer_wait_on(FiTasksCommandBufferHandle handle, bool *error) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_command_buffer_wait_on(FiTasksCommandBufferHandle handle, bool *error) {
     return handle.vtable->v0.wait_on(handle.data, error);
 }
 
@@ -861,7 +861,7 @@ static FIMO_INLINE_ALWAYS bool fi_tasks_ctx_is_worker(FiTasksContext ctx) { retu
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_task_id(FiTasksContext ctx, FimoUSize *id) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_task_id(FiTasksContext ctx, FimoUSize *id) {
     return ctx.vtable->v0.task_id(ctx.data, id);
 }
 
@@ -879,7 +879,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_task_id(FiTasksContext ctx, Fim
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_worker_id(FiTasksContext ctx, FimoUSize *id) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_worker_id(FiTasksContext ctx, FimoUSize *id) {
     return ctx.vtable->v0.worker_id(ctx.data, id);
 }
 
@@ -894,7 +894,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_worker_id(FiTasksContext ctx, F
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_worker_group(FiTasksContext ctx, FiTasksWorkerGroup *grp) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_worker_group(FiTasksContext ctx, FiTasksWorkerGroup *grp) {
     return ctx.vtable->v0.worker_group(ctx.data, grp);
 }
 
@@ -910,7 +910,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_worker_group(FiTasksContext ctx
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_worker_group_by_id(FiTasksContext ctx, FimoUSize id,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_worker_group_by_id(FiTasksContext ctx, FimoUSize id,
                                                                     FiTasksWorkerGroup *grp) {
     return ctx.vtable->v0.worker_group_by_id(ctx.data, id, grp);
 }
@@ -929,7 +929,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_worker_group_by_id(FiTasksConte
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_query_worker_groups(FiTasksContext ctx,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_query_worker_groups(FiTasksContext ctx,
                                                                      FiTasksWorkerGroupQuery **query) {
     return ctx.vtable->v0.query_worker_groups(ctx.data, query);
 }
@@ -945,7 +945,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_query_worker_groups(FiTasksCont
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_release_worker_group_query(FiTasksContext ctx,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_release_worker_group_query(FiTasksContext ctx,
                                                                             FiTasksWorkerGroupQuery *query) {
     return ctx.vtable->v0.release_worker_group_query(ctx.data, query);
 }
@@ -963,7 +963,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_release_worker_group_query(FiTa
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_create_worker_group(FiTasksContext ctx, FiTasksWorkerGroupConfig cfg,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_create_worker_group(FiTasksContext ctx, FiTasksWorkerGroupConfig cfg,
                                                                      FiTasksWorkerGroup *grp) {
     return ctx.vtable->v0.create_worker_group(ctx.data, cfg, grp);
 }
@@ -979,7 +979,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_create_worker_group(FiTasksCont
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_yield(FiTasksContext ctx) { return ctx.vtable->v0.yield(ctx.data); }
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_yield(FiTasksContext ctx) { return ctx.vtable->v0.yield(ctx.data); }
 
 /**
  * Aborts the current task.
@@ -999,7 +999,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_yield(FiTasksContext ctx) { ret
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_abort(FiTasksContext ctx, void *error) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_abort(FiTasksContext ctx, void *error) {
     return ctx.vtable->v0.abort(ctx.data, error);
 }
 
@@ -1029,7 +1029,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_abort(FiTasksContext ctx, void 
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_tss_set(FiTasksContext ctx, FiTasksTssKey key, void *value,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_tss_set(FiTasksContext ctx, FiTasksTssKey key, void *value,
                                                          FiTasksTssDtor dtor) {
     return ctx.vtable->v0.tss_set(ctx.data, key, value, dtor);
 }
@@ -1051,7 +1051,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_tss_set(FiTasksContext ctx, FiT
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_tss_get(FiTasksContext ctx, FiTasksTssKey key, void **value) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_tss_get(FiTasksContext ctx, FiTasksTssKey key, void **value) {
     return ctx.vtable->v0.tss_get(ctx.data, key, value);
 }
 
@@ -1073,7 +1073,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_tss_get(FiTasksContext ctx, FiT
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_tss_clear(FiTasksContext ctx, FiTasksTssKey key) {
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_tss_clear(FiTasksContext ctx, FiTasksTssKey key) {
     return ctx.vtable->v0.tss_clear(ctx.data, key);
 }
 
@@ -1123,7 +1123,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_tss_clear(FiTasksContext ctx, F
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_park_conditionally(
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_park_conditionally(
         FiTasksContext ctx, const void *key, bool (*validate)(void *), void *validate_data,
         void (*before_sleep)(void *), void *before_sleep_data, void (*timed_out)(void *, const void *, bool),
         void *timed_out_data, const void *park_token, const FimoDuration *timeout, FiTasksParkResult *result) {
@@ -1165,7 +1165,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_park_conditionally(
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_unpark_one(FiTasksContext ctx, const void *key,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_unpark_one(FiTasksContext ctx, const void *key,
                                                             const void *(*callback)(void *, FiTasksUnparkResult),
                                                             void *callback_data, FiTasksUnparkResult *result) {
     return ctx.vtable->v0.unpark_one(ctx.data, key, callback, callback_data, result);
@@ -1196,7 +1196,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_unpark_one(FiTasksContext ctx, 
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_unpark_all(FiTasksContext ctx, const void *key,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_unpark_all(FiTasksContext ctx, const void *key,
                                                             const void *unpark_token, FimoUSize *unparked_tasks) {
     return ctx.vtable->v0.unpark_all(ctx.data, key, unpark_token, unparked_tasks);
 }
@@ -1242,7 +1242,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_unpark_all(FiTasksContext ctx, 
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_unpark_requeue(
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_unpark_requeue(
         FiTasksContext ctx, const void *key_from, const void *key_to, FiTasksRequeueOp (*validate)(void *),
         void *validate_data, const void *(*callback)(void *, FiTasksRequeueOp, FiTasksUnparkResult),
         void *callback_data, FiTasksUnparkResult *result) {
@@ -1291,7 +1291,7 @@ static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_unpark_requeue(
  * @return Status code.
  */
 FIMO_MUST_USE
-static FIMO_INLINE_ALWAYS FimoError fi_tasks_ctx_unpark_filter(FiTasksContext ctx, const void *key,
+static FIMO_INLINE_ALWAYS FimoResult fi_tasks_ctx_unpark_filter(FiTasksContext ctx, const void *key,
                                                                FiTasksUnparkFilterOp (*filter)(void *, const void *),
                                                                void *filter_data,
                                                                const void *(*callback)(void *, FiTasksUnparkResult),

--- a/ffi_library/python_module_loader/include/fimo_python_module_loader/loader.h
+++ b/ffi_library/python_module_loader/include/fimo_python_module_loader/loader.h
@@ -67,7 +67,7 @@
  */
 typedef struct FipyRunString {
     void *data;
-    FimoError (*func)(void *data, const char *code, const char *home);
+    FimoResult (*func)(void *data, const char *code, const char *home);
 } FipyRunString;
 
 /**
@@ -75,7 +75,7 @@ typedef struct FipyRunString {
  */
 typedef struct FipyLoadModule {
     void *data;
-    FimoError (*func)(void *data, FimoModuleLoadingSet *set, const char *filepath);
+    FimoResult (*func)(void *data, FimoModuleLoadingSet *set, const char *filepath);
 } FipyLoadModule;
 
 /**
@@ -93,7 +93,7 @@ typedef struct FipyLoadModule {
  *
  * @return Status code.
  */
-static FIMO_INLINE_ALWAYS FimoError fipy_run_string(const FipyRunString *symbol, const char *code, const char *home) {
+static FIMO_INLINE_ALWAYS FimoResult fipy_run_string(const FipyRunString *symbol, const char *code, const char *home) {
     FIMO_DEBUG_ASSERT(symbol)
     return symbol->func(symbol->data, code, home);
 }
@@ -111,8 +111,8 @@ static FIMO_INLINE_ALWAYS FimoError fipy_run_string(const FipyRunString *symbol,
  *
  * @return Status code.
  */
-static FIMO_INLINE_ALWAYS FimoError fipy_load_module(const FipyLoadModule *symbol, FimoModuleLoadingSet *set,
-                                                     const char *filepath) {
+static FIMO_INLINE_ALWAYS FimoResult fipy_load_module(const FipyLoadModule *symbol, FimoModuleLoadingSet *set,
+                                                      const char *filepath) {
     FIMO_DEBUG_ASSERT(symbol)
     return symbol->func(symbol->data, set, filepath);
 }

--- a/modules/fimo_tasks_impl/src/worker_group/command_buffer.rs
+++ b/modules/fimo_tasks_impl/src/worker_group/command_buffer.rs
@@ -147,7 +147,7 @@ impl CommandBufferHandleFFI {
     unsafe extern "C" fn worker_group(
         this: *mut std::ffi::c_void,
         group: *mut bindings::FiTasksWorkerGroup,
-    ) -> std_bindings::FimoError {
+    ) -> std_bindings::FimoResult {
         fimo_std::panic::catch_unwind(|| {
             // Safety: Must be ensured by the caller.
             let this = unsafe { Self::borrow_from_ffi(this) };
@@ -159,14 +159,15 @@ impl CommandBufferHandleFFI {
             unsafe { group.write(WorkerGroupFFI(this.worker_group()?).into_ffi()) }
             Ok(())
         })
+        .map_err(Into::into)
         .flatten()
-        .map_or_else(|e| e.into_error(), |_| Error::EOK.into_error())
+        .into_ffi()
     }
 
     unsafe extern "C" fn wait_on(
         this: *mut std::ffi::c_void,
         aborted: *mut bool,
-    ) -> std_bindings::FimoError {
+    ) -> std_bindings::FimoResult {
         fimo_std::panic::catch_unwind(|| {
             // Safety: Is always in an `Arc`.
             let handle = unsafe { Self(Arc::from_raw(this.cast_const().cast())).0 };
@@ -186,8 +187,9 @@ impl CommandBufferHandleFFI {
                 }
             }
         })
+        .map_err(Into::into)
         .flatten()
-        .map_or_else(|e| e.into_error(), |_| Error::EOK.into_error())
+        .into_ffi()
     }
 }
 

--- a/modules/fimo_tasks_impl/src/worker_group/command_buffer.rs
+++ b/modules/fimo_tasks_impl/src/worker_group/command_buffer.rs
@@ -273,6 +273,7 @@ impl CommandBufferImpl {
         self.stack_size
     }
 
+    #[allow(dead_code)]
     pub fn mark_task_as_blocked(&mut self, index: usize, worker: Option<WorkerId>, task: RawTask) {
         let id = task.id();
         let old = self.blocked_tasks.insert(id, (index, worker, task));

--- a/modules/fimo_tasks_impl/src/worker_group/event_loop.rs
+++ b/modules/fimo_tasks_impl/src/worker_group/event_loop.rs
@@ -160,7 +160,7 @@ impl EventLoopHandle {
         let mut status = self
             .connection_status
             .write()
-            .map_err(|_e| Error::ECANCELED)?;
+            .map_err(|_e| <Error>::ECANCELED)?;
 
         // If the channel is already closed we can return.
         if *status == ConnectionStatus::Closed {
@@ -171,7 +171,7 @@ impl EventLoopHandle {
         self.outer_requests
             .try_send(OuterRequest::Close)
             .map_err(|e| match e {
-                TrySendError::Full(_) => Error::ECOMM,
+                TrySendError::Full(_) => <Error>::ECOMM,
                 TrySendError::Disconnected(_) => Error::ECONNABORTED,
             })?;
 
@@ -190,11 +190,11 @@ impl EventLoopHandle {
         let status = self
             .connection_status
             .read()
-            .map_err(|_e| Error::ECANCELED)?;
+            .map_err(|_e| <Error>::ECANCELED)?;
 
         // If the channel is already closed we can return.
         if *status == ConnectionStatus::Closed {
-            return Err(Error::ECANCELED);
+            return Err(<Error>::ECANCELED);
         }
 
         // Send the message.
@@ -202,8 +202,8 @@ impl EventLoopHandle {
         self.outer_requests
             .try_send(OuterRequest::EnqueueCommandBuffer(buffer))
             .map_err(|e| match e {
-                TrySendError::Full(_) => Error::ECOMM,
-                TrySendError::Disconnected(_) => Error::ECONNABORTED,
+                TrySendError::Full(_) => <Error>::ECOMM,
+                TrySendError::Disconnected(_) => <Error>::ECONNABORTED,
             })?;
 
         Ok(handle)
@@ -598,8 +598,8 @@ impl EventLoop {
                     .expect("allocator not found");
 
                 let stack = match allocator.acquire_stack() {
-                    Ok(stack) => stack,
-                    Err(Error::EBUSY) => {
+                    Ok(Some(stack)) => stack,
+                    Ok(None) => {
                         // If we aren't successful due to reaching the maximum number of
                         // allowed stacks we block the task.
                         fimo_std::emit_info!(

--- a/modules/fimo_tasks_impl/src/worker_group/event_loop/stack_manager.rs
+++ b/modules/fimo_tasks_impl/src/worker_group/event_loop/stack_manager.rs
@@ -143,12 +143,11 @@ impl StackAllocator {
         }
 
         let stack = if self.protected {
-            let stack = context::stack::ProtectedFixedSizeStack::new(self.size)
-                .map_err(|e| <Error>::new(e))?;
+            let stack =
+                context::stack::ProtectedFixedSizeStack::new(self.size).map_err(Error::new)?;
             StackMemory::Protected(stack)
         } else {
-            let stack =
-                context::stack::FixedSizeStack::new(self.size).map_err(|e| Error::new(e))?;
+            let stack = context::stack::FixedSizeStack::new(self.size).map_err(Error::new)?;
             StackMemory::Unprotected(stack)
         };
 

--- a/modules/fimo_tasks_impl/src/worker_group/worker_thread.rs
+++ b/modules/fimo_tasks_impl/src/worker_group/worker_thread.rs
@@ -311,12 +311,9 @@ impl WorkerContextLock {
 }
 
 pub fn with_worker_context_lock<R>(f: impl FnOnce(&mut WorkerContext) -> R) -> Result<R, Error> {
-    let guard = WORKER_THREAD
-        .0
-        .try_borrow_mut()
-        .map_err(|_e| Error::EDEADLK)?;
+    let guard = WORKER_THREAD.0.try_borrow_mut().map_err(Error::new)?;
     let mut worker =
-        RefMut::filter_map(guard, |worker| worker.as_mut()).map_err(|_e| Error::EPERM)?;
+        RefMut::filter_map(guard, |worker| worker.as_mut()).map_err(|_e| <Error>::EPERM)?;
     Ok(f(&mut worker))
 }
 

--- a/modules/python_module_loader/src/main.c
+++ b/modules/python_module_loader/src/main.c
@@ -20,13 +20,13 @@ FIMO_PRAGMA_MSVC(warning(pop))
 #define MODULE_FILE_NAME "module.so"
 #endif
 
-static FimoError construct_module_(const FimoModule *module, FimoModuleLoadingSet *set, void **data);
+static FimoResult construct_module_(const FimoModule *module, FimoModuleLoadingSet *set, void **data);
 static void destroy_module_(const FimoModule *module, void *data);
-static FimoError run_string_(void *data, const char *code, const char *home);
-static FimoError construct_run_string_(const FimoModule *module, void **symbol);
+static FimoResult run_string_(void *data, const char *code, const char *home);
+static FimoResult construct_run_string_(const FimoModule *module, void **symbol);
 static void destroy_run_string_(void *symbol);
-static FimoError load_module_(void *data, FimoModuleLoadingSet *set, const char *filepath);
-static FimoError construct_load_module_(const FimoModule *module, void **symbol);
+static FimoResult load_module_(void *data, FimoModuleLoadingSet *set, const char *filepath);
+static FimoResult construct_load_module_(const FimoModule *module, void **symbol);
 static void destroy_load_module_(void *symbol);
 
 static FimoModuleResourceDecl module_resources[] = {
@@ -68,9 +68,9 @@ FIMO_MODULE_EXPORT_MODULE(FIMO_CURRENT_MODULE_NAME, "Loader for Python modules",
                           FIMO_MODULE_EXPORT_MODULE_DYNAMIC_SYMBOL_EXPORTS(module_dynamic_exports),
                           FIMO_MODULE_EXPORT_MODULE_CONSTRUCTOR(construct_module_, destroy_module_))
 
-static FimoError construct_module_(const FimoModule *module, FimoModuleLoadingSet *set, void **data) {
-    FimoError error = fimo_context_check_version(module->context);
-    if (FIMO_IS_ERROR(error)) {
+static FimoResult construct_module_(const FimoModule *module, FimoModuleLoadingSet *set, void **data) {
+    FimoResult error = fimo_context_check_version(module->context);
+    if (FIMO_RESULT_IS_ERROR(error)) {
         return error;
     }
 
@@ -146,7 +146,7 @@ static FimoError construct_module_(const FimoModule *module, FimoModuleLoadingSe
 
 cleanup_config:
     PyConfig_Clear(&config);
-    return FIMO_EUNKNOWN;
+    return FIMO_RESULT_FROM_STRING("unknown error");
 }
 
 static void destroy_module_(const FimoModule *module, void *data) {
@@ -166,7 +166,7 @@ static void destroy_module_(const FimoModule *module, void *data) {
     FIMO_DEBUG_ASSERT_FALSE(result != 0)
 }
 
-static FimoError run_string_(void *data, const char *code, const char *home) {
+static FimoResult run_string_(void *data, const char *code, const char *home) {
     FIMO_DEBUG_ASSERT(data)
     const FimoModule *module = data;
     if (code == NULL) {
@@ -271,16 +271,16 @@ destroy_main_state:
     PyThreadState_Clear(state);
     PyThreadState_DeleteCurrent();
 
-    return FIMO_EUNKNOWN;
+    return FIMO_RESULT_FROM_STRING("unknown error");
 }
 
-static FimoError construct_run_string_(const FimoModule *module, void **symbol) {
+static FimoResult construct_run_string_(const FimoModule *module, void **symbol) {
     FIMO_DEBUG_ASSERT(module && symbol)
     FIMO_TRACING_EMIT_TRACE_SIMPLE(module->context, __func__, FIMO_CURRENT_MODULE_NAME, "initializing 'run_string'")
-    FimoError error;
+    FimoResult error;
     FipyRunString **run_string = (FipyRunString **)symbol;
     *run_string = fimo_malloc(sizeof(**run_string), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         FIMO_TRACING_EMIT_ERROR_SIMPLE(module->context, __func__, FIMO_CURRENT_MODULE_NAME,
                                        "could not allocate symbol");
     }
@@ -297,20 +297,20 @@ static void destroy_run_string_(void *symbol) {
     fimo_free(symbol);
 }
 
-static FimoError load_module_(void *data, FimoModuleLoadingSet *set, const char *filepath) {
+static FimoResult load_module_(void *data, FimoModuleLoadingSet *set, const char *filepath) {
     (void)data;
     (void)set;
     (void)filepath;
     return FIMO_ENOSYS;
 }
 
-static FimoError construct_load_module_(const FimoModule *module, void **symbol) {
+static FimoResult construct_load_module_(const FimoModule *module, void **symbol) {
     FIMO_DEBUG_ASSERT(module && symbol)
     FIMO_TRACING_EMIT_TRACE_SIMPLE(module->context, __func__, FIMO_CURRENT_MODULE_NAME, "initializing 'load_module'")
-    FimoError error;
+    FimoResult error;
     FipyLoadModule **load_module = (FipyLoadModule **)symbol;
     *load_module = fimo_malloc(sizeof(**load_module), &error);
-    if (FIMO_IS_ERROR(error)) {
+    if (FIMO_RESULT_IS_ERROR(error)) {
         FIMO_TRACING_EMIT_ERROR_SIMPLE(module->context, __func__, FIMO_CURRENT_MODULE_NAME,
                                        "could not allocate symbol");
     }

--- a/modules/python_module_loader/tests/run_string.cpp
+++ b/modules/python_module_loader/tests/run_string.cpp
@@ -19,11 +19,11 @@ TEST_CASE("Load module", "[python_module_loader]") {
     const FimoBaseStructIn *options[] = {reinterpret_cast<FimoBaseStructIn *>(&config), nullptr};
 
     FimoContext context;
-    FimoError error = fimo_context_init(options, &context);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    FimoResult error = fimo_context_init(options, &context);
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_tracing_register_thread(context);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     std::filesystem::path modules_dir = FIMO_MODULES_DIR;
     std::filesystem::path module_home = modules_dir / "python_module_loader";
@@ -41,30 +41,30 @@ TEST_CASE("Load module", "[python_module_loader]") {
 
     FimoModuleLoadingSet *set;
     error = fimo_module_set_new(context, &set);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_set_append_modules(
             context, set, module_path_string.c_str(), [](auto, auto) { return true; }, nullptr);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_set_finish(context, set);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     const FimoModule *pseudo_module;
     error = fimo_module_pseudo_module_new(context, &pseudo_module);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     fimo_context_release(context);
 
     const FimoModuleInfo *info;
     error = fimo_module_find_by_name(pseudo_module->context, "python_module_loader", &info);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     error = fimo_module_acquire_dependency(pseudo_module, info);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     FIMO_MODULE_INFO_RELEASE(info);
 
     error = fimo_module_namespace_include(pseudo_module, FIPY_SYMBOL_NAMESPACE);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     const FimoModuleRawSymbol *run_string_symbol;
     error = fimo_module_load_symbol(pseudo_module, FIPY_SYMBOL_NAME_RUN_STRING, FIPY_SYMBOL_NAMESPACE,
@@ -72,11 +72,11 @@ TEST_CASE("Load module", "[python_module_loader]") {
                                                  FIPY_SYMBOL_VERSION_MINOR_RUN_STRING,
                                                  FIPY_SYMBOL_VERSION_PATCH_RUN_STRING),
                                     &run_string_symbol);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
 
     auto run_string = static_cast<const FipyRunString *>(FIMO_MODULE_SYMBOL_LOCK(run_string_symbol));
     error = fipy_run_string(run_string, R"(print("Hello Python!"))", nullptr);
-    REQUIRE_FALSE(FIMO_IS_ERROR(error));
+    REQUIRE_FALSE(FIMO_RESULT_IS_ERROR(error));
     FIMO_MODULE_SYMBOL_RELEASE(run_string_symbol);
 
     fimo_context_release(context);

--- a/python/fimo_std/src/fimo_std/ffi/ctypes_patch.py
+++ b/python/fimo_std/src/fimo_std/ffi/ctypes_patch.py
@@ -1,0 +1,342 @@
+# Copyright (c) 2014 Russell Keith-Magee.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     1. Redistributions of source code must retain the above copyright notice,
+#        this list of conditions and the following disclaimer.
+#
+#     2. Redistributions in binary form must reproduce the above copyright
+#        notice, this list of conditions and the following disclaimer in the
+#        documentation and/or other materials provided with the distribution.
+#
+#     3. Neither the name of Rubicon nor the names of its contributors may
+#        be used to endorse or promote products derived from this software without
+#        specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+"""This module provides a workaround to allow callback functions to return
+composite types (most importantly structs).
+
+Currently, ctypes callback functions (created by passing a Python callable to a
+CFUNCTYPE object) are only able to return what ctypes considers a "simple" type. This
+includes void (None), scalars (c_int, c_float, etc.), c_void_p, c_char_p, c_wchar_p, and
+py_object. Returning "composite" types (structs, unions, and non-"simple" pointers) is
+not possible. This issue has been reported on the Python bug tracker
+(https://github.com/python/cpython/issues/49960).
+
+For pointers, the easiest workaround is to return a c_void_p instead of the correctly
+typed pointer, and to cast the value on both sides. For structs and unions there is no
+easy workaround, which is why this somewhat hacky workaround is necessary.
+"""
+
+import ctypes
+import sys
+import types
+import warnings
+
+# This module relies on the layout of a few internal Python and ctypes
+# structures. Because of this, it's possible (but not all that likely) that
+# things will break on newer/older Python versions.
+if sys.version_info < (3, 6) or sys.version_info >= (3, 14):
+    v = sys.version_info
+    warnings.warn(
+        "rubicon.objc.ctypes_patch has only been tested with Python 3.6 through 3.13. "
+        f"You are using Python {v.major}.{v.minor}.{v.micro}. Most likely things will "
+        "work properly, but you may experience crashes if Python's internals have "
+        "changed significantly."
+    )
+
+
+# The PyTypeObject struct from "Include/object.h".
+# This is a forward declaration, fields are set later once PyVarObject has been declared.
+class PyTypeObject(ctypes.Structure):
+    pass
+
+
+# The PyObject struct from "Include/object.h".
+class PyObject(ctypes.Structure):
+    _fields_ = [
+        ("ob_refcnt", ctypes.c_ssize_t),
+        ("ob_type", ctypes.POINTER(PyTypeObject)),
+    ]
+
+
+# The PyVarObject struct from "Include/object.h".
+class PyVarObject(ctypes.Structure):
+    _fields_ = [
+        ("ob_base", PyObject),
+        ("ob_size", ctypes.c_ssize_t),
+    ]
+
+
+# This structure is not stable across Python versions, but the few fields that
+# we use probably won't change.
+PyTypeObject._fields_ = [
+    ("ob_base", PyVarObject),
+    ("tp_name", ctypes.c_char_p),
+    ("tp_basicsize", ctypes.c_ssize_t),
+    ("tp_itemsize", ctypes.c_ssize_t),
+    # There are many more fields, but we're only interested in the size fields,
+    # so we can leave out everything else.
+]
+
+
+# The ffi_type structure from libffi's "include/ffi.h". This is a forward
+# declaration, because the structure contains pointers to itself.
+class ffi_type(ctypes.Structure):
+    pass
+
+
+ffi_type._fields_ = [
+    ("size", ctypes.c_size_t),
+    ("alignment", ctypes.c_ushort),
+    ("type", ctypes.c_ushort),
+    ("elements", ctypes.POINTER(ctypes.POINTER(ffi_type))),
+]
+
+
+# The GETFUNC and SETFUNC typedefs from "Modules/_ctypes/ctypes.h".
+GETFUNC = ctypes.PYFUNCTYPE(ctypes.py_object, ctypes.c_void_p, ctypes.c_ssize_t)
+# The return type of SETFUNC is declared here as a c_void_p instead of py_object to work
+# around a ctypes bug (https://github.com/python/cpython/issues/81061). See the comment
+# in make_callback_returnable's setfunc for details.
+SETFUNC = ctypes.PYFUNCTYPE(
+    ctypes.c_void_p, ctypes.c_void_p, ctypes.py_object, ctypes.c_ssize_t
+)
+
+
+if sys.version_info < (3, 13):
+    # The PyTypeObject structure for the dict class.
+    # This is used to determine the size of the PyDictObject structure.
+    PyDict_Type = PyTypeObject.from_address(id(dict))
+
+    # The PyDictObject structure from "Include/dictobject.h". This structure is not
+    # stable across Python versions, and did indeed change in recent Python
+    # releases. Because we only care about the size of the structure and not its
+    # actual contents, we can declare it as an opaque byte array, with the length
+    # taken from PyDict_Type.
+    class PyDictObject(ctypes.Structure):
+        _fields_ = [
+            ("PyDictObject_opaque", (ctypes.c_ubyte * PyDict_Type.tp_basicsize)),
+        ]
+
+    # The StgDictObject structure from "Modules/_ctypes/ctypes.h". This structure is
+    # not officially stable across Python versions, but it didn't change between being
+    # introduced in 2009, and being replaced in 2024/Python 3.13.0a6.
+    class StgDictObject(ctypes.Structure):
+        _fields_ = [
+            ("dict", PyDictObject),
+            ("size", ctypes.c_ssize_t),
+            ("align", ctypes.c_ssize_t),
+            ("length", ctypes.c_ssize_t),
+            ("ffi_type_pointer", ffi_type),
+            ("proto", ctypes.py_object),
+            ("setfunc", SETFUNC),
+            ("getfunc", GETFUNC),
+            # There are a few more fields, but we leave them out again because
+            # we don't need them.
+        ]
+
+    # The mappingproxyobject struct from "Objects/descrobject.c". This structure is
+    # not officially stable across Python versions, but its layout hasn't changed
+    # since 2001.
+    class mappingproxyobject(ctypes.Structure):
+        _fields_ = [
+            ("ob_base", PyObject),
+            ("mapping", ctypes.py_object),
+        ]
+
+    def unwrap_mappingproxy(proxy):
+        """Return the mapping contained in a mapping proxy object."""
+
+        if not isinstance(proxy, types.MappingProxyType):
+            raise TypeError(
+                "Expected a mapping proxy object, not "
+                f"{type(proxy).__module__}.{type(proxy).__qualname__}"
+            )
+
+        return mappingproxyobject.from_address(id(proxy)).mapping
+
+    def get_stgdict_of_type(tp):
+        """Return the given ctypes type's StgDict object. If the object's dict is
+        not a StgDict, an error is raised.
+
+        This function is roughly equivalent to the PyType_stgdict function in the
+        ctypes source code. We cannot use that function directly, because it is not
+        part of CPython's public C API, and thus not accessible on some systems (see
+        #113).
+        """
+
+        if not isinstance(tp, type):
+            raise TypeError(
+                "Expected a type object, not "
+                f"{type(tp).__module__}.{type(tp).__qualname__}"
+            )
+
+        stgdict = tp.__dict__
+        if isinstance(stgdict, types.MappingProxyType):
+            # If the type's __dict__ is wrapped in a mapping proxy, we need to
+            # unwrap it. (This appears to always be the case, so the isinstance
+            # check above could perhaps be left out, but it doesn't hurt to check.)
+            stgdict = unwrap_mappingproxy(stgdict)
+
+        # The StgDict type is not publicly exposed anywhere, so we can't use
+        # isinstance. Checking the name is the best we can do here.
+        if type(stgdict).__name__ != "StgDict":
+            raise TypeError(
+                "The given type's dict must be a StgDict, not "
+                f"{type(stgdict).__module__}.{type(stgdict).__qualname__}"
+            )
+
+        return StgDictObject.from_address(id(stgdict))
+
+else:
+    # In Python 3.13.0a6 (https://github.com/python/cpython/issues/114314),
+    # StgDict was replaced with a new StgInfo data type that requires less
+    # metaclass magic.
+
+    class StgInfo(ctypes.Structure):
+        _fields_ = [
+            ("initialized", ctypes.c_int),
+            ("size", ctypes.c_ssize_t),
+            ("align", ctypes.c_ssize_t),
+            ("length", ctypes.c_ssize_t),
+            ("ffi_type_pointer", ffi_type),
+            ("proto", ctypes.py_object),
+            ("setfunc", SETFUNC),
+            ("getfunc", GETFUNC),
+            # There are a few more fields, but we leave them out again because
+            # we don't need them.
+        ]
+
+    # void *PyObject_GetTypeData(PyObject *o, PyTypeObject *cls);
+    ctypes.pythonapi.PyObject_GetTypeData.restype = ctypes.c_void_p
+    ctypes.pythonapi.PyObject_GetTypeData.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+
+    def get_stginfo_of_type(tp):
+        """Return the given ctypes type's StgInfo object.
+
+        This function is roughly equivalent to the PyStgInfo_FromType function in the
+        ctypes source code. We cannot use that function directly, because it is not
+        part of CPython's public C API, and thus not accessible).
+        """
+        # Original code:
+        #     if (!PyObject_IsInstance((PyObject *)type, (PyObject *)state->PyCType_Type))
+        if not isinstance(tp, type(ctypes.Structure).__base__):
+            raise TypeError(
+                "Expected a ctypes structure type, "
+                f"not {type(tp).__module__}.{type(tp).__qualname__}"
+            )
+
+        # tp is the Python representation of the type. The StgInfo struct is the
+        # type data stored on ctypes.CType_Type (which is the base class of
+        # ctypes.Structure).
+        # Original code:
+        #     StgInfo *info = PyObject_GetTypeData((PyObject *)type, state->PyCType_Type);
+        info = ctypes.pythonapi.PyObject_GetTypeData(
+            id(tp),
+            id(type(ctypes.Structure).__base__),
+        )
+        result = StgInfo.from_address(info)
+        if not result.initialized:
+            raise TypeError(
+                f"{type(tp).__module__}.{type(tp).__qualname__} has not been "
+                "initialized; it may be an abstract class"
+            )
+
+        return result
+
+
+ctypes.pythonapi.Py_IncRef.restype = None
+ctypes.pythonapi.Py_IncRef.argtypes = [ctypes.POINTER(PyObject)]
+
+
+def make_callback_returnable(ctype):
+    """Modify the given ctypes type so it can be returned from a callback
+    function.
+
+    This function may be used as a decorator on a struct/union declaration.
+
+    The method is idempotent; it only modifies the type the first time it
+    is invoked on a type.
+    """
+    # The presence of the _rubicon_objc_ctypes_patch_getfunc attribute is a
+    # sentinel for whether the type has been modified previously.
+    if hasattr(ctype, "_rubicon_objc_ctypes_patch_getfunc"):
+        return ctype
+
+    # The implementation changed in 3.13.0a6; StgDict was replaced with StgInfo
+    if sys.version_info < (3, 13):
+        stg = get_stgdict_of_type(ctype)
+    else:
+        stg = get_stginfo_of_type(ctype)
+
+    # Ensure that there is no existing getfunc or setfunc on the stgdict.
+    if ctypes.cast(stg.getfunc, ctypes.c_void_p).value is not None:
+        raise ValueError(
+            f"The ctype {ctype.__module__}.{ctype.__name__} already has a getfunc"
+        )
+    elif ctypes.cast(stg.setfunc, ctypes.c_void_p).value is not None:
+        raise ValueError(
+            f"The ctype {ctype.__module__}.{ctype.__name__} already has a setfunc"
+        )
+
+    # Define the getfunc and setfunc.
+    @GETFUNC
+    def getfunc(ptr, size):
+        actual_size = ctypes.sizeof(ctype)
+        if size != 0 and size != actual_size:
+            raise ValueError(
+                f"getfunc for ctype {ctype}: Requested size {size} "
+                f"does not match actual size {actual_size}"
+            )
+
+        return ctype.from_buffer_copy(ctypes.string_at(ptr, actual_size))
+
+    @SETFUNC
+    def setfunc(ptr, value, size):
+        actual_size = ctypes.sizeof(ctype)
+        if size != 0 and size != actual_size:
+            raise ValueError(
+                f"setfunc for ctype {ctype}: Requested size {size} "
+                f"does not match actual size {actual_size}"
+            )
+
+        ctypes.memmove(ptr, ctypes.addressof(value), actual_size)
+        # Because of a ctypes bug (https://github.com/python/cpython/issues/81061),
+        # returning None from a callback with restype py_object causes a reference
+        # counting error that can crash Python. To work around this bug, the restype of
+        # SETFUNC is declared as c_void_p instead. This way ctypes performs no automatic
+        # reference counting for the returned object, which avoids the bug. However,
+        # this way we have to manually convert the Python object to a pointer and adjust
+        # its reference count.
+        none_ptr = ctypes.cast(id(None), ctypes.POINTER(PyObject))
+        # The return value of a SETFUNC is expected to have an extra reference
+        # (which will be owned by the caller of the SETFUNC).
+        ctypes.pythonapi.Py_IncRef(none_ptr)
+        # The returned pointer must be returned as a plain int, not as a c_void_p,
+        # otherwise ctypes won't recognize it and will raise a TypeError.
+        return ctypes.cast(none_ptr, ctypes.c_void_p).value
+
+    # Store the getfunc and setfunc as attributes on the ctype, so they don't
+    # get garbage-collected.
+    ctype._rubicon_objc_ctypes_patch_getfunc = getfunc
+    ctype._rubicon_objc_ctypes_patch_setfunc = setfunc
+
+    # Put the getfunc and setfunc into the stg fields.
+    stg.getfunc = getfunc
+    stg.setfunc = setfunc
+
+    # Return the passed in ctype, so this function can be used as a decorator.
+    return ctype

--- a/python/fimo_std/src/fimo_std/memory.py
+++ b/python/fimo_std/src/fimo_std/memory.py
@@ -28,9 +28,9 @@ class DefaultAllocator:
         :return: Allocated pointer
         :raises Error: Buffer could not be allocated
         """
-        err = _ffi.FimoError(0)
+        err = _ffi.FimoResult()
         result = _ffi.fimo_malloc(c.c_size_t(size), c.byref(err))
-        error.ErrorCode(err.value).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return result
 
     @staticmethod
@@ -47,9 +47,9 @@ class DefaultAllocator:
             - Allocated size
         :raises Error: Buffer could not be allocated
         """
-        err = _ffi.FimoError(0)
+        err = _ffi.FimoResult()
         result = _ffi.fimo_malloc_sized(c.c_size_t(size), c.byref(err))
-        error.ErrorCode(err.value).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         ptr = result.ptr
         buff_size = result.buff_size
@@ -68,9 +68,9 @@ class DefaultAllocator:
         :return: Allocated pointer
         :raises Error: Buffer could not be allocated
         """
-        err = _ffi.FimoError(0)
+        err = _ffi.FimoResult()
         result = _ffi.fimo_calloc(c.c_size_t(size), c.byref(err))
-        error.ErrorCode(err.value).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return result
 
     @staticmethod
@@ -87,9 +87,9 @@ class DefaultAllocator:
             - Allocated size
         :raises Error: Buffer could not be allocated
         """
-        err = _ffi.FimoError(0)
+        err = _ffi.FimoResult()
         result = _ffi.fimo_calloc_sized(c.c_size_t(size), c.byref(err))
-        error.ErrorCode(err.value).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         ptr = result.ptr
         buff_size = result.buff_size
@@ -109,11 +109,11 @@ class DefaultAllocator:
         :return: Allocated pointer
         :raises Error: Buffer could not be allocated
         """
-        err = _ffi.FimoError(0)
+        err = _ffi.FimoResult()
         result = _ffi.fimo_aligned_alloc(
             c.c_size_t(alignment), c.c_size_t(size), c.byref(err)
         )
-        error.ErrorCode(err.value).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return result
 
     @staticmethod
@@ -131,11 +131,11 @@ class DefaultAllocator:
             - Allocated size
         :raises Error: Buffer could not be allocated
         """
-        err = _ffi.FimoError(0)
+        err = _ffi.FimoResult()
         result = _ffi.fimo_aligned_alloc_sized(
             c.c_size_t(alignment), c.c_size_t(size), c.byref(err)
         )
-        error.ErrorCode(err.value).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         ptr = result.ptr
         buff_size = result.buff_size

--- a/python/fimo_std/src/fimo_std/module.py
+++ b/python/fimo_std/src/fimo_std/module.py
@@ -110,7 +110,7 @@ class ModuleInfoView(
             raise TypeError("`ctx` must be an instance of `ContextView`")
 
         err = _ffi.fimo_module_unload(ctx.ffi, self.ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def is_loaded(self) -> bool:
         """Checks whether the underlying module is still loaded."""
@@ -122,7 +122,7 @@ class ModuleInfoView(
         The module may be locked multiple times.
         """
         err = _ffi.fimo_impl_module_info_lock_unload(self.ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
@@ -181,7 +181,7 @@ class ModuleInfo(
         module_ffi = c.POINTER(_ffi.FimoModuleInfo)()
         name_ffi = c.c_char_p(name.encode())
         err = _ffi.fimo_module_find_by_name(ctx.ffi, name_ffi, c.byref(module_ffi))
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         return cls(module_ffi)
 
@@ -206,7 +206,7 @@ class ModuleInfo(
         err = _ffi.fimo_module_find_by_symbol(
             ctx.ffi, name_ffi, namespace_ffi, version_ffi, c.byref(module_ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         return cls(module_ffi)
 
@@ -503,7 +503,7 @@ class ModuleBase(
         err = _ffi.fimo_module_namespace_included(
             self.ffi, namespace_ffi, c.byref(is_included_ffi), c.byref(is_static_ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         if not is_included_ffi.value:
             return None
@@ -523,7 +523,7 @@ class ModuleBase(
 
         namespace_ffi = c.c_char_p(namespace.encode())
         err = _ffi.fimo_module_namespace_include(self.ffi, namespace_ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def exclude_namespace(self, namespace: str) -> None:
         """Removes a namespace from the module.
@@ -537,7 +537,7 @@ class ModuleBase(
 
         namespace_ffi = c.c_char_p(namespace.encode())
         err = _ffi.fimo_module_namespace_exclude(self.ffi, namespace_ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def has_dependency(self, module: ModuleInfoView) -> Optional[DependencyType]:
         """Checks if a module depends on another module.
@@ -554,7 +554,7 @@ class ModuleBase(
         err = _ffi.fimo_module_has_dependency(
             self.ffi, module_ffi, c.byref(has_dependency_ffi), c.byref(is_static_ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         if not has_dependency_ffi.value:
             return None
@@ -576,7 +576,7 @@ class ModuleBase(
 
         module_ffi = module.ffi
         err = _ffi.fimo_module_acquire_dependency(self.ffi, module_ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def remove_dependency(self, module: ModuleInfoView) -> None:
         """Removes a module as a dependency.
@@ -591,7 +591,7 @@ class ModuleBase(
 
         module_ffi = module.ffi
         err = _ffi.fimo_module_relinquish_dependency(self.ffi, module_ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     # noinspection PyProtectedMember
     def load_symbol(self, sym_type: type[Symbol[_T]]) -> Symbol[_T]:
@@ -635,7 +635,7 @@ class ModuleBase(
         err = _ffi.fimo_module_load_symbol(
             self.ffi, name_ffi, namespace_ffi, version_ffi, c.byref(symbol_ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         return RawSymbol(symbol_ffi)
 
@@ -687,7 +687,7 @@ class PseudoModule(_OpaqueModule):
 
         module_ffi = c.POINTER(_ffi.FimoModule)()
         err = _ffi.fimo_module_pseudo_module_new(ctx.ffi, c.byref(module_ffi))
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         super().__init__(module_ffi)
 
@@ -699,7 +699,7 @@ class PseudoModule(_OpaqueModule):
         """Destroys the `PseudoModule."""
         ctx_ffi = _ffi.FimoContext()
         err = _ffi.fimo_module_pseudo_module_destroy(self.ffi, c.byref(ctx_ffi))
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         self._consume()
         return context.Context.transfer_from_ffi(ctx_ffi)
 
@@ -872,7 +872,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_get_public(
             ctx.ffi, value_ffi_ptr, c.byref(type_ffi), module_ffi, parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         type = ParameterType.transfer_from_ffi(type_ffi)
 
         match type:
@@ -926,7 +926,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_get_dependency(
             caller.ffi, value_ffi_ptr, c.byref(type_ffi), module_ffi, parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         type = ParameterType.transfer_from_ffi(type_ffi)
 
         match type:
@@ -972,7 +972,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_get_private(
             caller.ffi, value_ffi_ptr, c.byref(type_ffi), parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         type = ParameterType.transfer_from_ffi(type_ffi)
 
         match type:
@@ -1018,7 +1018,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_get_inner(
             caller.ffi, value_ffi_ptr, c.byref(type_ffi), parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         type = ParameterType.transfer_from_ffi(type_ffi)
 
         match type:
@@ -1087,7 +1087,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_set_public(
             ctx.ffi, value_ffi_ptr, type_ffi, module_ffi, parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def write_dependency(self, caller: ModuleBase, module: str, parameter: str) -> None:
         """Writes a module parameter with dependency write access.
@@ -1135,7 +1135,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_set_dependency(
             caller.ffi, value_ffi_ptr, type_ffi, module_ffi, parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def write_private(self, caller: ModuleBase, parameter: Parameter) -> None:
         """Writes a module parameter with private write access.
@@ -1175,7 +1175,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_set_private(
             caller.ffi, value_ffi_ptr, type_ffi, parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def write_inner(self, caller: ModuleBase, parameter: ParameterData) -> None:
         """Writes a module parameter.
@@ -1215,7 +1215,7 @@ class ParameterValue:
         err = _ffi.fimo_module_param_set_inner(
             caller.ffi, value_ffi_ptr, type_ffi, parameter_ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
     def __repr__(self) -> str:
         return f"ParameterValue.{self._type}({self._value})"
@@ -1964,7 +1964,7 @@ class LoadingSetView(
         err = _ffi.fimo_module_set_has_module(
             ctx.ffi, self.ffi, name_ffi, c.byref(has_module_ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         return has_module_ffi.value
 
@@ -1994,7 +1994,7 @@ class LoadingSetView(
             version_ffi,
             c.byref(has_symbol_ffi),
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         return has_symbol_ffi.value
 
@@ -2034,7 +2034,7 @@ class LoadingSetView(
             _loading_set_callback_on_error_func,
             c.c_void_p.from_buffer(wrapper_ffi),
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         # Since the callbacks will be passed to a C-interface it must take
         # ownership of the object. We do this by increasing the reference count
@@ -2069,7 +2069,7 @@ class LoadingSetView(
         err = _ffi.fimo_module_set_append_freestanding_module(
             owner.ffi, self.ffi, export.ffi
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         # Now that we transferred the export without an error we also confirm it
         # on the python side
@@ -2128,7 +2128,7 @@ class LoadingSetView(
         err = _ffi.fimo_module_set_append_modules(
             ctx.ffi, self.ffi, module_path_ffi, filter_ffi, c.c_void_p()
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
 
 class LoadingSet(
@@ -2181,7 +2181,7 @@ class LoadingSet(
 
         ffi = c.POINTER(_ffi.FimoModuleLoadingSet)()
         err = _ffi.fimo_module_set_new(ctx.ffi, c.byref(ffi))
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         return cls(ffi, ctx)
 
@@ -2193,7 +2193,7 @@ class LoadingSet(
         """
         assert self._ctx is not None
         err = _ffi.fimo_module_set_dismiss(self._ctx.ffi, self.ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         self._consume()
         del self._ctx
@@ -2211,7 +2211,7 @@ class LoadingSet(
         """
         assert self._ctx is not None
         err = _ffi.fimo_module_set_finish(self._ctx.ffi, self.ffi)
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         self._consume()
         del self._ctx
@@ -2329,7 +2329,7 @@ class ModuleCtx:
         err = _ffi.fimo_module_namespace_exists(
             self.context.ffi, namespace_ffi, c.byref(exists_ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         return exists_ffi.value
 
@@ -2810,7 +2810,7 @@ def export_module(
                 value_addr: int,
                 type_ffi: _ffi.FimoModuleParamType,
                 data_ffi: _ffi.Pointer[_ffi.FimoModuleParamData],
-            ) -> error.ErrorCode:
+            ) -> _ffi.FimoResult:
                 try:
                     module = module_type.transfer_from_ffi(module_ffi)
                     value_ffi = c.c_void_p(value_addr)
@@ -2855,16 +2855,16 @@ def export_module(
                     data = ParameterData.borrow_from_ffi(data_ffi)
                     setter(module, parameter, data)
 
-                    return error.ErrorCode.EOK
+                    return error.Result.new(None).transfer_to_ffi()
                 except Exception as e:
-                    return error.ErrorCode.from_exception(e)
+                    return error.Result.new(e).transfer_to_ffi()
 
             def getter_wrapper(
                 module_ffi: _ffi.Pointer[_ffi.FimoModule],
                 value_addr: int,
                 type_ffi: _ffi.Pointer[_ffi.FimoModuleParamType],
                 data_ffi: _ffi.Pointer[_ffi.FimoModuleParamData],
-            ) -> error.ErrorCode:
+            ) -> _ffi.FimoResult:
                 try:
                     module = module_type.transfer_from_ffi(module_ffi)
                     value_ffi = c.c_void_p(value_addr)
@@ -2911,9 +2911,9 @@ def export_module(
                         case _:
                             raise ValueError("unknown parameter type")
 
-                    return error.ErrorCode.EOK
+                    return error.Result.new(None).transfer_to_ffi()
                 except Exception as e:
-                    return error.ErrorCode.from_exception(e)
+                    return error.Result.new(e).transfer_to_ffi()
 
             # noinspection PyProtectedMember
             default_ffi = _ffi._FimoModuleParamDeclDefaultValue()
@@ -3018,13 +3018,13 @@ def export_module(
 
             def ffi_symbol_constructor(
                 module_ffi: _ffi.Pointer[_ffi.FimoModule], sym: _ffi.Pointer[c.c_void_p]
-            ) -> error.ErrorCode:
+            ) -> _ffi.FimoResult:
                 try:
                     module = module_type.transfer_from_ffi(module_ffi)
                     symbol_constructor(module, sym)
-                    return error.ErrorCode.EOK
+                    return error.Result.new(None).transfer_to_ffi()
                 except Exception as e:
-                    return error.ErrorCode.from_exception(e)
+                    return error.Result.new(e).transfer_to_ffi()
 
             def ffi_symbol_destructor(ffi_address: Optional[int]) -> None:
                 # noinspection PyBroadException
@@ -3054,7 +3054,7 @@ def export_module(
         module_ffi: _ffi.Pointer[_ffi.FimoModule],
         module_set_ffi: _ffi.Pointer[_ffi.FimoModuleLoadingSet],
         data_ffi: _ffi.Pointer[c.c_void_p],
-    ) -> error.ErrorCode:
+    ) -> _ffi.FimoResult:
         try:
             module = module_type.transfer_from_ffi(module_ffi)
             assert isinstance(module, ModuleBase)
@@ -3069,9 +3069,9 @@ def export_module(
             data_ffi[0] = obj_ptr
             _ffi.c_inc_ref(obj)
 
-            return error.ErrorCode.EOK
+            return error.Result.new(None).transfer_to_ffi()
         except Exception as e:
-            return error.ErrorCode.from_exception(e)
+            return error.Result.new(e).transfer_to_ffi()
 
     def destructor(
         _module_ffi: _ffi.Pointer[_ffi.FimoModule], data_address: Optional[int]

--- a/python/fimo_std/src/fimo_std/tests/test_error.py
+++ b/python/fimo_std/src/fimo_std/tests/test_error.py
@@ -1,30 +1,40 @@
 import pytest
 
-from ..error import ErrorCode, Error
+from ..error import ErrorCode, Error, Result
 
 
-def test_is_valid():
+def test_new():
+    result = Result.new(None)
+    assert result.is_ok()
+    assert not result.is_error()
+
+    result = Result.new("test error")
+    assert result.is_error()
+    print(result.name)
+    print(result.description)
+
+
+def test_error_code():
     for c in ErrorCode:
-        assert isinstance(c.is_valid(), bool)
-        assert c.is_valid()
-
-
-def test_is_error():
-    for c in ErrorCode:
-        assert isinstance(c.is_error(), bool)
+        result = Result.from_error_code(c)
+        assert isinstance(result.is_ok(), bool)
+        assert isinstance(result.is_error(), bool)
         if c == ErrorCode.EOK:
-            assert not c.is_error()
+            assert result.is_ok()
+            assert not result.is_error()
         else:
-            assert c.is_error()
+            assert not result.is_ok()
+            assert result.is_error()
 
 
 def test_raise_if_error():
     for c in ErrorCode:
-        if not c.is_error():
-            c.raise_if_error()
+        result = Result.from_error_code(c)
+        if not result.is_error():
+            result.raise_if_error()
         else:
             with pytest.raises(Error):
-                c.raise_if_error()
+                result.raise_if_error()
 
 
 def test_name():
@@ -32,8 +42,16 @@ def test_name():
         assert isinstance(c.name, str)
         print(c.name)
 
+        result = Result.from_error_code(c)
+        assert isinstance(result.name, str)
+        print(result.name)
+
 
 def test_description():
     for c in ErrorCode:
         assert isinstance(c.description, str)
         print(c.description)
+
+        result = Result.from_error_code(c)
+        assert isinstance(result.description, str)
+        print(result.description)

--- a/python/fimo_std/src/fimo_std/time.py
+++ b/python/fimo_std/src/fimo_std/time.py
@@ -145,7 +145,7 @@ class Duration(_ffi.FFITransferable[_ffi.FimoDuration]):
         err = _ffi.fimo_duration_add(
             c.byref(self._ffi), c.byref(other._ffi), c.byref(ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return Duration.transfer_from_ffi(ffi)
 
     def saturating_add(self, other: Self) -> "Duration":
@@ -170,7 +170,7 @@ class Duration(_ffi.FFITransferable[_ffi.FimoDuration]):
         err = _ffi.fimo_duration_sub(
             c.byref(self._ffi), c.byref(other._ffi), c.byref(ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return Duration.transfer_from_ffi(ffi)
 
     def saturating_sub(self, other: Self) -> "Duration":
@@ -274,7 +274,7 @@ class Time(_ffi.FFITransferable[_ffi.FimoTime]):
         """
         ffi = _ffi.FimoDuration()
         err = _ffi.fimo_time_elapsed(c.byref(self._ffi), c.byref(ffi))
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return Duration.transfer_from_ffi(ffi)
 
     def duration_since(self, earlier: "Time") -> Duration:
@@ -291,7 +291,7 @@ class Time(_ffi.FFITransferable[_ffi.FimoTime]):
         err = _ffi.fimo_time_duration_since(
             c.byref(self._ffi), c.byref(earlier._ffi), c.byref(ffi)
         )
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return Duration.transfer_from_ffi(ffi)
 
     def __add__(self, other: Duration) -> "Time":
@@ -301,7 +301,7 @@ class Time(_ffi.FFITransferable[_ffi.FimoTime]):
         ffi = _ffi.FimoTime()
         other_ffi = other.transfer_to_ffi()
         err = _ffi.fimo_time_add(c.byref(self._ffi), c.byref(other_ffi), c.byref(ffi))
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return Time.transfer_from_ffi(ffi)
 
     def saturating_add(self, other: Duration) -> "Time":
@@ -326,7 +326,7 @@ class Time(_ffi.FFITransferable[_ffi.FimoTime]):
         ffi = _ffi.FimoTime()
         other_ffi = other.transfer_to_ffi()
         err = _ffi.fimo_time_sub(c.byref(self._ffi), c.byref(other_ffi), c.byref(ffi))
-        error.ErrorCode.transfer_from_ffi(err).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
         return Time.transfer_from_ffi(ffi)
 
     def saturating_sub(self, other: Duration) -> "Time":

--- a/python/fimo_std/src/fimo_std/version.py
+++ b/python/fimo_std/src/fimo_std/version.py
@@ -15,13 +15,13 @@ class Version(_ffi.FFITransferable[_ffi.FimoVersion]):
             build = 0
 
         if not isinstance(major, int) or not 0 <= major <= 4_294_967_295:
-            error.ErrorCode.EINVAL.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
         if not isinstance(minor, int) or not 0 <= minor <= 4_294_967_295:
-            error.ErrorCode.EINVAL.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
         if not isinstance(patch, int) or not 0 <= patch <= 4_294_967_295:
-            error.ErrorCode.EINVAL.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
         if not isinstance(build, int) or not 0 <= build <= 18_446_744_073_709_551_615:
-            error.ErrorCode.EINVAL.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
 
         self._version = _ffi.FimoVersion(major, minor, patch, build)
 
@@ -52,14 +52,14 @@ class Version(_ffi.FFITransferable[_ffi.FimoVersion]):
         :raises Error: Version could not be parsed
         """
         if not isinstance(string, str):
-            error.ErrorCode.EINVAL.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
 
         string_ = string.encode()
         vers = _ffi.FimoVersion()
         err = _ffi.fimo_version_parse_str(
             c.c_char_p(string_), c.c_size_t(len(string_)), c.byref(vers)
         )
-        error.ErrorCode(err.value).raise_if_error()
+        error.Result.transfer_from_ffi(err).raise_if_error()
 
         major = vers.major.value
         minor = vers.minor.value
@@ -84,7 +84,7 @@ class Version(_ffi.FFITransferable[_ffi.FimoVersion]):
         err_ffi = _ffi.fimo_version_write_str(
             c.byref(self._version), buffer_str, c.c_size_t(length), None
         )
-        err = error.ErrorCode(err_ffi.value)
+        err = error.Result.transfer_from_ffi(err_ffi)
 
         if err.is_error():
             memory.DefaultAllocator.free(buffer)
@@ -102,7 +102,7 @@ class Version(_ffi.FFITransferable[_ffi.FimoVersion]):
         err_ffi = _ffi.fimo_version_write_str_long(
             c.byref(self._version), buffer_str, c.c_size_t(length), None
         )
-        err = error.ErrorCode(err_ffi.value)
+        err = error.Result.transfer_from_ffi(err_ffi)
 
         if err.is_error():
             memory.DefaultAllocator.free(buffer)
@@ -122,7 +122,7 @@ class Version(_ffi.FFITransferable[_ffi.FimoVersion]):
         :raises Error: `other` is not a `Version`
         """
         if not isinstance(other, Version):
-            error.ErrorCode.EINTR.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
 
         return _ffi.fimo_version_cmp(c.byref(self._version), c.byref(other._version))
 
@@ -136,7 +136,7 @@ class Version(_ffi.FFITransferable[_ffi.FimoVersion]):
         :raises Error: `other` is not a `Version`
         """
         if not isinstance(other, Version):
-            error.ErrorCode.EINTR.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
 
         return _ffi.fimo_version_cmp_long(
             c.byref(self._version), c.byref(other._version)
@@ -160,7 +160,7 @@ class Version(_ffi.FFITransferable[_ffi.FimoVersion]):
         :raises Error: `required` is not a `Version`
         """
         if not isinstance(required, Version):
-            error.ErrorCode.EINTR.raise_if_error()
+            error.Result.from_error_code(error.ErrorCode.EINVAL).raise_if_error()
 
         return _ffi.fimo_version_compatible(
             c.byref(self._version), c.byref(required._version)

--- a/rust/fimo_std/src/allocator.rs
+++ b/rust/fimo_std/src/allocator.rs
@@ -27,9 +27,9 @@ unsafe impl GlobalAlloc for FimoAllocator {
         let align = layout.align();
 
         // Safety: error is a valid pointer.
-        match to_result_indirect(|error| unsafe {
-            bindings::fimo_aligned_alloc(align, size, error)
-        }) {
+        match unsafe {
+            to_result_indirect(|error| bindings::fimo_aligned_alloc(align, size, error))
+        } {
             Ok(ptr) => {
                 debug_assert!(
                     !ptr.is_null(),
@@ -62,9 +62,9 @@ unsafe impl Allocator for FimoAllocator {
         }
 
         // Safety: error is a valid pointer.
-        match to_result_indirect(|error| unsafe {
-            bindings::fimo_aligned_alloc_sized(align, size, error)
-        }) {
+        match unsafe {
+            to_result_indirect(|error| bindings::fimo_aligned_alloc_sized(align, size, error))
+        } {
             Ok(buffer) => {
                 debug_assert!(
                     !buffer.ptr.is_null(),

--- a/rust/fimo_std/src/context.rs
+++ b/rust/fimo_std/src/context.rs
@@ -33,7 +33,8 @@ impl ContextView<'_> {
     pub fn check_version(&self) -> crate::error::Result {
         // Safety: The call is safe, as we own a reference to the context.
         let error = unsafe { bindings::fimo_context_check_version(self.0) };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     /// Promotes the context view to a context, by increasing the reference count.

--- a/rust/fimo_std/src/error.rs
+++ b/rust/fimo_std/src/error.rs
@@ -1,176 +1,348 @@
 //! Fimo error codes.
 
-use core::{ffi::CStr, fmt, mem::MaybeUninit};
-
-use crate::bindings;
+use crate::{bindings, ffi::FFITransferable};
+use std::{
+    ffi::{CStr, CString},
+    fmt,
+    marker::PhantomData,
+    mem::{ManuallyDrop, MaybeUninit},
+    ops::Deref,
+};
 
 /// Generic error code.
-///
-/// The error codes are based on the POSIX errno codes.
-#[derive(Clone, Copy, PartialEq, Eq, Hash)]
-pub struct Error(bindings::FimoError);
+#[derive(PartialEq, Eq, Hash)]
+pub struct Error<T: ?Sized = *const ()>(bindings::FimoResult, PhantomData<T>);
 
 mod __private {
     use paste::paste;
 
     macro_rules! new_error {
-        ($err:ident, $($doc:literal),+) => {
+        ($code:ident, $err:ident, $($doc:literal),+) => {
             paste! {
-                impl super::Error {
+                impl<T: ?Sized> super::Error<T> {
                     $(
                         #[doc = $doc]
                     )+
-                    pub const $err: Self = Self(crate::bindings::FimoError::[<FIMO_ $err>]);
+                    pub const $err: Self = Self(
+                        crate::bindings::FimoResult {
+                            data: std::ptr::without_provenance_mut(crate::bindings::FimoErrorCode::[<FIMO_ $code>].0 as usize),
+                            // Safety: Is guaranteed to be valid.
+                            vtable: unsafe{ &crate::bindings::FIMO_IMPL_RESULT_ERROR_CODE_VTABLE }
+                        },
+                        std::marker::PhantomData,
+                    );
                 }
             }
         };
     }
 
-    new_error!(EOK, "Operation completed successfully");
-    new_error!(E2BIG, "Argument list too long");
-    new_error!(EACCES, "Permission denied");
-    new_error!(EADDRINUSE, "Address already in use");
-    new_error!(EADDRNOTAVAIL, "Address not available");
-    new_error!(EAFNOSUPPORT, "Address family not supported");
-    new_error!(EAGAIN, "Resource temporarily unavailable");
-    new_error!(EALREADY, "Connection already in progress");
-    new_error!(EBADE, "Invalid exchange");
-    new_error!(EBADF, "Bad file descriptor");
-    new_error!(EBADFD, "File descriptor in bad state");
-    new_error!(EBADMSG, "Bad message");
-    new_error!(EBADR, "Invalid request descriptor");
-    new_error!(EBADRQC, "Invalid request code");
-    new_error!(EBADSLT, "Invalid slot");
-    new_error!(EBUSY, "Device or resource busy");
-    new_error!(ECANCELED, "Operation canceled");
-    new_error!(ECHILD, "No child processes");
-    new_error!(ECHRNG, "Channel number out of range");
-    new_error!(ECOMM, "Communication error on send");
-    new_error!(ECONNABORTED, "Connection aborted");
-    new_error!(ECONNREFUSED, "Connection refused");
-    new_error!(ECONNRESET, "Connection reset");
-    new_error!(EDEADLK, "Resource deadlock avoided");
+    impl<T: ?Sized> super::Error<T> {
+        pub(super) const FFI_OK_RESULT: crate::bindings::FimoResult = crate::bindings::FimoResult {
+            data: std::ptr::null_mut(),
+            vtable: std::ptr::null_mut(),
+        };
+    }
+
+    new_error!(ERROR_CODE_2BIG, E2BIG, "Argument list too long");
+    new_error!(ERROR_CODE_ACCES, EACCES, "Permission denied");
+    new_error!(ERROR_CODE_ADDRINUSE, EADDRINUSE, "Address already in use");
     new_error!(
+        ERROR_CODE_ADDRNOTAVAIL,
+        EADDRNOTAVAIL,
+        "Address not available"
+    );
+    new_error!(
+        ERROR_CODE_AFNOSUPPORT,
+        EAFNOSUPPORT,
+        "Address family not supported"
+    );
+    new_error!(ERROR_CODE_AGAIN, EAGAIN, "Resource temporarily unavailable");
+    new_error!(
+        ERROR_CODE_ALREADY,
+        EALREADY,
+        "Connection already in progress"
+    );
+    new_error!(ERROR_CODE_BADE, EBADE, "Invalid exchange");
+    new_error!(ERROR_CODE_BADF, EBADF, "Bad file descriptor");
+    new_error!(ERROR_CODE_BADFD, EBADFD, "File descriptor in bad state");
+    new_error!(ERROR_CODE_BADMSG, EBADMSG, "Bad message");
+    new_error!(ERROR_CODE_BADR, EBADR, "Invalid request descriptor");
+    new_error!(ERROR_CODE_BADRQC, EBADRQC, "Invalid request code");
+    new_error!(ERROR_CODE_BADSLT, EBADSLT, "Invalid slot");
+    new_error!(ERROR_CODE_BUSY, EBUSY, "Device or resource busy");
+    new_error!(ERROR_CODE_CANCELED, ECANCELED, "Operation canceled");
+    new_error!(ERROR_CODE_CHILD, ECHILD, "No child processes");
+    new_error!(ERROR_CODE_CHRNG, ECHRNG, "Channel number out of range");
+    new_error!(ERROR_CODE_COMM, ECOMM, "Communication error on send");
+    new_error!(ERROR_CODE_CONNABORTED, ECONNABORTED, "Connection aborted");
+    new_error!(ERROR_CODE_CONNREFUSED, ECONNREFUSED, "Connection refused");
+    new_error!(ERROR_CODE_CONNRESET, ECONNRESET, "Connection reset");
+    new_error!(ERROR_CODE_DEADLK, EDEADLK, "Resource deadlock avoided");
+    new_error!(
+        ERROR_CODE_DEADLOCK,
         EDEADLOCK,
         "File locking deadlock error (or Resource deadlock avoided)"
     );
-    new_error!(EDESTADDRREQ, "Destination address required");
-    new_error!(EDOM, "Mathematics argument out of domain of function");
-    new_error!(EDQUOT, "Disk quota exceeded");
-    new_error!(EEXIST, "File exists");
-    new_error!(EFAULT, "Bad address");
-    new_error!(EFBIG, "File too large");
-    new_error!(EHOSTDOWN, "Host is down");
-    new_error!(EHOSTUNREACH, "Host is unreachable");
-    new_error!(EHWPOISON, "Memory page has hardware error");
-    new_error!(EIDRM, "Identifier removed");
-    new_error!(EILSEQ, "Invalid or incomplete multibyte or wide character");
-    new_error!(EINPROGRESS, "Operation in progress");
-    new_error!(EINTR, "Interrupted function call");
-    new_error!(EINVAL, "Invalid argument");
-    new_error!(EIO, "Input/output error");
-    new_error!(EISCONN, "Socket is connected");
-    new_error!(EISDIR, "Is a directory");
-    new_error!(EISNAM, "Is a named type file");
-    new_error!(EKEYEXPIRED, "Key has expired");
-    new_error!(EKEYREJECTED, "Key was rejected by service");
-    new_error!(EKEYREVOKED, "Key has been revoked");
-    new_error!(EL2HLT, "Level 2 halted");
-    new_error!(EL2NSYNC, "Level 2 not synchronized");
-    new_error!(EL3HLT, "Level 3 halted");
-    new_error!(EL3RST, "Level 3 reset");
-    new_error!(ELIBACC, "Cannot access a needed shared library");
-    new_error!(ELIBBAD, "Accessing a corrupted shared library");
-    new_error!(ELIBMAX, "Attempting to link in too many shared libraries");
-    new_error!(ELIBSCN, ".lib section in a.out corrupted");
-    new_error!(ELIBEXEC, "Cannot exec a shared library directly");
-    new_error!(ELNRNG, "Link number out of range");
-    new_error!(ELOOP, "Too many levels of symbolic links");
-    new_error!(EMEDIUMTYPE, "Wrong medium type");
-    new_error!(EMFILE, "Too many open files");
-    new_error!(EMLINK, "Too many links");
-    new_error!(EMSGSIZE, "Message too long");
-    new_error!(EMULTIHOP, "Multihop attempted");
-    new_error!(ENAMETOOLONG, "Filename too long");
-    new_error!(ENETDOWN, "Network is down");
-    new_error!(ENETRESET, "Connection aborted by network");
-    new_error!(ENETUNREACH, "Network unreachable");
-    new_error!(ENFILE, "Too many open files in system");
-    new_error!(ENOANO, "No anode");
-    new_error!(ENOBUFS, "No buffer space available");
     new_error!(
+        ERROR_CODE_DESTADDRREQ,
+        EDESTADDRREQ,
+        "Destination address required"
+    );
+    new_error!(
+        ERROR_CODE_DOM,
+        EDOM,
+        "Mathematics argument out of domain of function"
+    );
+    new_error!(ERROR_CODE_DQUOT, EDQUOT, "Disk quota exceeded");
+    new_error!(ERROR_CODE_EXIST, EEXIST, "File exists");
+    new_error!(ERROR_CODE_FAULT, EFAULT, "Bad address");
+    new_error!(ERROR_CODE_FBIG, EFBIG, "File too large");
+    new_error!(ERROR_CODE_HOSTDOWN, EHOSTDOWN, "Host is down");
+    new_error!(ERROR_CODE_HOSTUNREACH, EHOSTUNREACH, "Host is unreachable");
+    new_error!(
+        ERROR_CODE_HWPOISON,
+        EHWPOISON,
+        "Memory page has hardware error"
+    );
+    new_error!(ERROR_CODE_IDRM, EIDRM, "Identifier removed");
+    new_error!(
+        ERROR_CODE_ILSEQ,
+        EILSEQ,
+        "Invalid or incomplete multibyte or wide character"
+    );
+    new_error!(ERROR_CODE_INPROGRESS, EINPROGRESS, "Operation in progress");
+    new_error!(ERROR_CODE_INTR, EINTR, "Interrupted function call");
+    new_error!(ERROR_CODE_INVAL, EINVAL, "Invalid argument");
+    new_error!(ERROR_CODE_IO, EIO, "Input/output error");
+    new_error!(ERROR_CODE_ISCONN, EISCONN, "Socket is connected");
+    new_error!(ERROR_CODE_ISDIR, EISDIR, "Is a directory");
+    new_error!(ERROR_CODE_ISNAM, EISNAM, "Is a named type file");
+    new_error!(ERROR_CODE_KEYEXPIRED, EKEYEXPIRED, "Key has expired");
+    new_error!(
+        ERROR_CODE_KEYREJECTED,
+        EKEYREJECTED,
+        "Key was rejected by service"
+    );
+    new_error!(ERROR_CODE_KEYREVOKED, EKEYREVOKED, "Key has been revoked");
+    new_error!(ERROR_CODE_L2HLT, EL2HLT, "Level 2 halted");
+    new_error!(ERROR_CODE_L2NSYNC, EL2NSYNC, "Level 2 not synchronized");
+    new_error!(ERROR_CODE_L3HLT, EL3HLT, "Level 3 halted");
+    new_error!(ERROR_CODE_L3RST, EL3RST, "Level 3 reset");
+    new_error!(
+        ERROR_CODE_LIBACC,
+        ELIBACC,
+        "Cannot access a needed shared library"
+    );
+    new_error!(
+        ERROR_CODE_LIBBAD,
+        ELIBBAD,
+        "Accessing a corrupted shared library"
+    );
+    new_error!(
+        ERROR_CODE_LIBMAX,
+        ELIBMAX,
+        "Attempting to link in too many shared libraries"
+    );
+    new_error!(
+        ERROR_CODE_LIBSCN,
+        ELIBSCN,
+        ".lib section in a.out corrupted"
+    );
+    new_error!(
+        ERROR_CODE_LIBEXEC,
+        ELIBEXEC,
+        "Cannot exec a shared library directly"
+    );
+    new_error!(ERROR_CODE_LNRNG, ELNRNG, "Link number out of range");
+    new_error!(ERROR_CODE_LOOP, ELOOP, "Too many levels of symbolic links");
+    new_error!(ERROR_CODE_MEDIUMTYPE, EMEDIUMTYPE, "Wrong medium type");
+    new_error!(ERROR_CODE_MFILE, EMFILE, "Too many open files");
+    new_error!(ERROR_CODE_MLINK, EMLINK, "Too many links");
+    new_error!(ERROR_CODE_MSGSIZE, EMSGSIZE, "Message too long");
+    new_error!(ERROR_CODE_MULTIHOP, EMULTIHOP, "Multihop attempted");
+    new_error!(ERROR_CODE_NAMETOOLONG, ENAMETOOLONG, "Filename too long");
+    new_error!(ERROR_CODE_NETDOWN, ENETDOWN, "Network is down");
+    new_error!(
+        ERROR_CODE_NETRESET,
+        ENETRESET,
+        "Connection aborted by network"
+    );
+    new_error!(ERROR_CODE_NETUNREACH, ENETUNREACH, "Network unreachable");
+    new_error!(ERROR_CODE_NFILE, ENFILE, "Too many open files in system");
+    new_error!(ERROR_CODE_NOANO, ENOANO, "No anode");
+    new_error!(ERROR_CODE_NOBUFS, ENOBUFS, "No buffer space available");
+    new_error!(
+        ERROR_CODE_NODATA,
         ENODATA,
         "The named attribute does not exist, or the process has no access to this attribute"
     );
-    new_error!(ENODEV, "No such device");
-    new_error!(ENOENT, "No such file or directory");
-    new_error!(ENOEXEC, "Exec format error");
-    new_error!(ENOKEY, "Required key not available");
-    new_error!(ENOLCK, "No locks available");
-    new_error!(ENOLINK, "Link has been severed");
-    new_error!(ENOMEDIUM, "No medium found");
-    new_error!(ENOMEM, "Not enough space/cannot allocate memory");
-    new_error!(ENOMSG, "No message of the desired type");
-    new_error!(ENONET, "Machine is not on the network");
-    new_error!(ENOPKG, "Package not installed");
-    new_error!(ENOPROTOOPT, "Protocol not available");
-    new_error!(ENOSPC, "No space left on device");
-    new_error!(ENOSR, "No STREAM resources");
-    new_error!(ENOSTR, "Not a STREAM");
-    new_error!(ENOSYS, "Function not implemented");
-    new_error!(ENOTBLK, "Block device required");
-    new_error!(ENOTCONN, "The socket is not connected");
-    new_error!(ENOTDIR, "Not a directory");
-    new_error!(ENOTEMPTY, "Directory not empty");
-    new_error!(ENOTRECOVERABLE, "State not recoverable");
-    new_error!(ENOTSOCK, "Not a socket");
-    new_error!(ENOTSUP, "Operation not supported");
-    new_error!(ENOTTY, "Inappropriate I/O control operation");
-    new_error!(ENOTUNIQ, "Name not unique on network");
-    new_error!(ENXIO, "No such device or address");
-    new_error!(EOPNOTSUPP, "Operation not supported on socket");
-    new_error!(EOVERFLOW, "Value too large to be stored in data type");
-    new_error!(EOWNERDEAD, "Owner died");
-    new_error!(EPERM, "Operation not permitted");
-    new_error!(EPFNOSUPPORT, "Protocol family not supported");
-    new_error!(EPIPE, "Broken pipe");
-    new_error!(EPROTO, "Protocol error");
-    new_error!(EPROTONOSUPPORT, "Protocol not supported");
-    new_error!(EPROTOTYPE, "Protocol wrong type for socket");
-    new_error!(ERANGE, "Result too large");
-    new_error!(EREMCHG, "Remote address changed");
-    new_error!(EREMOTE, "Object is remote");
-    new_error!(EREMOTEIO, "Remote I/O error");
-    new_error!(ERESTART, "Interrupted system call should be restarted");
-    new_error!(ERFKILL, "Operation not possible due to RF-kill");
-    new_error!(EROFS, "Read-only filesystem");
-    new_error!(ESHUTDOWN, "Cannot send after transport endpoint shutdown");
-    new_error!(ESPIPE, "Invalid seek");
-    new_error!(ESOCKTNOSUPPORT, "Socket type not supported");
-    new_error!(ESRCH, "No such process");
-    new_error!(ESTALE, "Stale file handle");
-    new_error!(ESTRPIPE, "Streams pipe error");
-    new_error!(ETIME, "Timer expired");
-    new_error!(ETOOMANYREFS, "Too many references: cannot splice");
-    new_error!(ETXTBSY, "Text file busy");
-    new_error!(EUCLEAN, "Structure needs cleaning");
-    new_error!(EUNATCH, "Protocol driver not attached");
-    new_error!(EUSERS, "Too many users");
-    new_error!(EWOULDBLOCK, "Operation would block");
-    new_error!(EXDEV, "Invalid cross-device link");
-    new_error!(EXFULL, "Exchange full");
-    new_error!(EUNKNOWN, "Unknown error");
+    new_error!(ERROR_CODE_NODEV, ENODEV, "No such device");
+    new_error!(ERROR_CODE_NOENT, ENOENT, "No such file or directory");
+    new_error!(ERROR_CODE_NOEXEC, ENOEXEC, "Exec format error");
+    new_error!(ERROR_CODE_NOKEY, ENOKEY, "Required key not available");
+    new_error!(ERROR_CODE_NOLCK, ENOLCK, "No locks available");
+    new_error!(ERROR_CODE_NOLINK, ENOLINK, "Link has been severed");
+    new_error!(ERROR_CODE_NOMEDIUM, ENOMEDIUM, "No medium found");
+    new_error!(
+        ERROR_CODE_NOMEM,
+        ENOMEM,
+        "Not enough space/cannot allocate memory"
+    );
+    new_error!(ERROR_CODE_NOMSG, ENOMSG, "No message of the desired type");
+    new_error!(ERROR_CODE_NONET, ENONET, "Machine is not on the network");
+    new_error!(ERROR_CODE_NOPKG, ENOPKG, "Package not installed");
+    new_error!(ERROR_CODE_NOPROTOOPT, ENOPROTOOPT, "Protocol not available");
+    new_error!(ERROR_CODE_NOSPC, ENOSPC, "No space left on device");
+    new_error!(ERROR_CODE_NOSR, ENOSR, "No STREAM resources");
+    new_error!(ERROR_CODE_NOSTR, ENOSTR, "Not a STREAM");
+    new_error!(ERROR_CODE_NOSYS, ENOSYS, "Function not implemented");
+    new_error!(ERROR_CODE_NOTBLK, ENOTBLK, "Block device required");
+    new_error!(ERROR_CODE_NOTCONN, ENOTCONN, "The socket is not connected");
+    new_error!(ERROR_CODE_NOTDIR, ENOTDIR, "Not a directory");
+    new_error!(ERROR_CODE_NOTEMPTY, ENOTEMPTY, "Directory not empty");
+    new_error!(
+        ERROR_CODE_NOTRECOVERABLE,
+        ENOTRECOVERABLE,
+        "State not recoverable"
+    );
+    new_error!(ERROR_CODE_NOTSOCK, ENOTSOCK, "Not a socket");
+    new_error!(ERROR_CODE_NOTSUP, ENOTSUP, "Operation not supported");
+    new_error!(
+        ERROR_CODE_NOTTY,
+        ENOTTY,
+        "Inappropriate I/O control operation"
+    );
+    new_error!(ERROR_CODE_NOTUNIQ, ENOTUNIQ, "Name not unique on network");
+    new_error!(ERROR_CODE_NXIO, ENXIO, "No such device or address");
+    new_error!(
+        ERROR_CODE_OPNOTSUPP,
+        EOPNOTSUPP,
+        "Operation not supported on socket"
+    );
+    new_error!(
+        ERROR_CODE_OVERFLOW,
+        EOVERFLOW,
+        "Value too large to be stored in data type"
+    );
+    new_error!(ERROR_CODE_OWNERDEAD, EOWNERDEAD, "Owner died");
+    new_error!(ERROR_CODE_PERM, EPERM, "Operation not permitted");
+    new_error!(
+        ERROR_CODE_PFNOSUPPORT,
+        EPFNOSUPPORT,
+        "Protocol family not supported"
+    );
+    new_error!(ERROR_CODE_PIPE, EPIPE, "Broken pipe");
+    new_error!(ERROR_CODE_PROTO, EPROTO, "Protocol error");
+    new_error!(
+        ERROR_CODE_PROTONOSUPPORT,
+        EPROTONOSUPPORT,
+        "Protocol not supported"
+    );
+    new_error!(
+        ERROR_CODE_PROTOTYPE,
+        EPROTOTYPE,
+        "Protocol wrong type for socket"
+    );
+    new_error!(ERROR_CODE_RANGE, ERANGE, "Result too large");
+    new_error!(ERROR_CODE_REMCHG, EREMCHG, "Remote address changed");
+    new_error!(ERROR_CODE_REMOTE, EREMOTE, "Object is remote");
+    new_error!(ERROR_CODE_REMOTEIO, EREMOTEIO, "Remote I/O error");
+    new_error!(
+        ERROR_CODE_RESTART,
+        ERESTART,
+        "Interrupted system call should be restarted"
+    );
+    new_error!(
+        ERROR_CODE_RFKILL,
+        ERFKILL,
+        "Operation not possible due to RF-kill"
+    );
+    new_error!(ERROR_CODE_ROFS, EROFS, "Read-only filesystem");
+    new_error!(
+        ERROR_CODE_SHUTDOWN,
+        ESHUTDOWN,
+        "Cannot send after transport endpoint shutdown"
+    );
+    new_error!(ERROR_CODE_SPIPE, ESPIPE, "Invalid seek");
+    new_error!(
+        ERROR_CODE_SOCKTNOSUPPORT,
+        ESOCKTNOSUPPORT,
+        "Socket type not supported"
+    );
+    new_error!(ERROR_CODE_SRCH, ESRCH, "No such process");
+    new_error!(ERROR_CODE_STALE, ESTALE, "Stale file handle");
+    new_error!(ERROR_CODE_STRPIPE, ESTRPIPE, "Streams pipe error");
+    new_error!(ERROR_CODE_TIME, ETIME, "Timer expired");
+    new_error!(
+        ERROR_CODE_TOOMANYREFS,
+        ETOOMANYREFS,
+        "Too many references: cannot splice"
+    );
+    new_error!(ERROR_CODE_TXTBSY, ETXTBSY, "Text file busy");
+    new_error!(ERROR_CODE_UCLEAN, EUCLEAN, "Structure needs cleaning");
+    new_error!(ERROR_CODE_UNATCH, EUNATCH, "Protocol driver not attached");
+    new_error!(ERROR_CODE_USERS, EUSERS, "Too many users");
+    new_error!(ERROR_CODE_WOULDBLOCK, EWOULDBLOCK, "Operation would block");
+    new_error!(ERROR_CODE_XDEV, EXDEV, "Invalid cross-device link");
+    new_error!(ERROR_CODE_XFULL, EXFULL, "Exchange full");
 }
 
 impl Error {
+    /// Creates an [`Error`] from an arbitrary value that can be formatted.
+    pub fn new(value: impl fmt::Display + fmt::Debug + 'static) -> Self {
+        let error = <Error>::new_error(value).into_error();
+        Self(error, PhantomData)
+    }
+}
+
+impl Error<dyn Send> {
+    /// Creates an [`Error`] from an arbitrary value that can be formatted.
+    pub fn new_send(value: impl fmt::Display + fmt::Debug + Send + 'static) -> Self {
+        let error = <Error>::new_error(value).into_error();
+        Self(error, PhantomData)
+    }
+}
+
+impl Error<dyn Sync> {
+    /// Creates an [`Error`] from an arbitrary value that can be formatted.
+    pub fn new_sync(value: impl fmt::Display + fmt::Debug + Sync + 'static) -> Self {
+        let error = <Error>::new_error(value).into_error();
+        Self(error, PhantomData)
+    }
+}
+
+impl Error<dyn Send + Sync> {
+    /// Creates an [`Error`] from an arbitrary value that can be formatted.
+    pub fn new_send_sync(value: impl fmt::Display + fmt::Debug + Send + Sync + 'static) -> Self {
+        let error = <Error>::new_error(value).into_error();
+        Self(error, PhantomData)
+    }
+}
+
+impl<T: ?Sized> Error<T> {
+    /// Creates an [`Error`] from a string.
+    pub fn from_string(error: &'static CStr) -> Self {
+        Self(
+            bindings::FimoResult {
+                data: error.as_ptr().cast_mut().cast(),
+                // Safety: Is guaranteed to be valid.
+                vtable: unsafe { &bindings::FIMO_IMPL_RESULT_STATIC_STRING_VTABLE },
+            },
+            PhantomData,
+        )
+    }
+
     /// Creates an [`Error`] from an error code.
     ///
-    /// In case of an invalid error code, this returns `EINVAL`.
-    pub fn from_error(error: bindings::FimoError) -> Self {
-        if !is_valid_error(error) {
-            Self(bindings::FimoError::FIMO_EINVAL)
+    /// In case of an invalid error code, this returns `Err`.
+    pub fn from_error_code(
+        error: bindings::FimoErrorCode,
+    ) -> Result<Self, bindings::FimoErrorCode> {
+        if !is_valid_error_code(error) {
+            Err(error)
         } else {
-            Self(error)
+            // Safety: We checked the validity.
+            unsafe { Ok(Self::from_error_code_unchecked(error)) }
         }
     }
 
@@ -178,93 +350,325 @@ impl Error {
     ///
     /// # Safety
     ///
-    /// `error` must be a valid error code.
-    pub unsafe fn from_error_unchecked(error: bindings::FimoError) -> Self {
-        Self(error)
+    /// `error` must be a valid error code and not
+    /// [`FIMO_ERROR_CODE_OK`](bindings::FimoErrorCode::FIMO_ERROR_CODE_OK).
+    pub unsafe fn from_error_code_unchecked(error: bindings::FimoErrorCode) -> Self {
+        Self(
+            bindings::FimoResult {
+                data: std::ptr::without_provenance_mut(error.0 as usize),
+                // Safety: Is guaranteed to be valid.
+                vtable: unsafe { &bindings::FIMO_IMPL_RESULT_ERROR_CODE_VTABLE },
+            },
+            PhantomData,
+        )
+    }
+
+    /// Creates an [`Error`] from a system error code.
+    pub fn from_system_error(error: bindings::FimoSystemErrorCode) -> Self {
+        Self(
+            bindings::FimoResult {
+                data: std::ptr::without_provenance_mut(error as usize),
+                // Safety: Is guaranteed to be valid.
+                vtable: unsafe { &bindings::FIMO_IMPL_RESULT_SYSTEM_ERROR_CODE_VTABLE },
+            },
+            PhantomData,
+        )
     }
 
     /// Returns the error code.
-    pub fn into_error(self) -> bindings::FimoError {
-        self.0
+    pub fn into_error(self) -> bindings::FimoResult {
+        let this = ManuallyDrop::new(self);
+        this.0
     }
 
     /// Constructs an [`Error`] from an errno value.
     pub fn from_errno(errnum: core::ffi::c_int) -> Self {
         // Safety: The function is safe to be called.
-        unsafe { Self(crate::bindings::fimo_error_from_errno(errnum)) }
+        let errnum = unsafe { bindings::fimo_error_code_from_errno(errnum) };
+        Self::from_error_code(errnum).expect("unknown error code")
     }
 
-    /// Returns a string representing the error, if one exists.
-    pub fn name(&self) -> Option<&'static str> {
-        let mut error = bindings::FimoError::FIMO_EOK;
-
-        // Safety: The error pointer is valid.
-        let ptr = unsafe { bindings::fimo_strerrorname(self.0, &mut error) };
-
-        if is_error(error) {
-            None
-        } else {
-            // Safety: The string returned by `fimo_strerrorname` is static and `NULL`-terminated.
-            let name = unsafe { CStr::from_ptr(ptr) };
-
-            // Safety: These strings are ASCII-only.
-            unsafe { Some(core::str::from_utf8_unchecked(name.to_bytes())) }
+    /// Returns a string representing the error.
+    pub fn name(&self) -> ErrorString {
+        let vtable = self.vtable();
+        // Safety: FFI call is always safe.
+        unsafe {
+            let string = vtable.v0.error_name.unwrap_unchecked()(self.0.data);
+            ErrorString(string)
         }
     }
 
-    /// Returns a string describing the error, if one exists.
-    pub fn description(&self) -> Option<&'static str> {
-        let mut error = bindings::FimoError::FIMO_EOK;
-
-        // Safety: The error pointer is valid.
-        let ptr = unsafe { bindings::fimo_strerrordesc(self.0, &mut error) };
-
-        if is_error(error) {
-            None
-        } else {
-            // Safety: The string returned by `fimo_strerrordesc` is static and `NULL`-terminated.
-            let desc = unsafe { CStr::from_ptr(ptr) };
-
-            // Safety: These strings are ASCII-only.
-            unsafe { Some(core::str::from_utf8_unchecked(desc.to_bytes())) }
+    /// Returns a string describing the error.
+    pub fn description(&self) -> ErrorString {
+        let vtable = self.vtable();
+        // Safety: FFI call is always safe.
+        unsafe {
+            let string = vtable.v0.error_description.unwrap_unchecked()(self.0.data);
+            ErrorString(string)
         }
+    }
+
+    fn vtable(&self) -> &bindings::FimoResultVTable {
+        // Safety: All fields are guaranteed to be initialized.
+        unsafe { &*self.0.vtable }
     }
 }
 
-fn is_error(errnum: bindings::FimoError) -> bool {
-    errnum.0 > bindings::FimoError::FIMO_EOK.0 && is_valid_error(errnum)
-}
-
-fn is_valid_error(errnum: bindings::FimoError) -> bool {
-    (bindings::FimoError::FIMO_EOK.0..=bindings::FimoError::FIMO_EUNKNOWN.0).contains(&errnum.0)
+fn is_valid_error_code(errnum: bindings::FimoErrorCode) -> bool {
+    (bindings::FimoErrorCode::FIMO_ERROR_CODE_2BIG.0
+        ..=bindings::FimoErrorCode::FIMO_ERROR_CODE_XFULL.0)
+        .contains(&errnum.0)
 }
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.name() {
-            Some(name) => f.debug_tuple(name).finish(),
-            None => f.debug_tuple("Error").field(&self.0).finish(),
-        }
+        let name = self.name();
+        f.debug_tuple("Error").field(&&*name).finish()
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.description() {
-            Some(description) => f.write_str(description),
-            None => write!(f, "Unknown error code"),
+        let description = self.description();
+        write!(f, "{}", description.to_string_lossy())
+    }
+}
+
+impl<T: ?Sized> Drop for Error<T> {
+    fn drop(&mut self) {
+        let vtable = self.vtable();
+        if let Some(release) = vtable.v0.release {
+            // Safety: FFI call is always safe.
+            unsafe {
+                release(self.0.data);
+            }
         }
+    }
+}
+
+// Safety: Is equivalent to a Box<dyn Send>.
+unsafe impl<T: ?Sized + Send> Send for Error<T> {}
+
+// Safety: Is equivalent to a Box<dyn Sync>.
+unsafe impl<T: ?Sized + Sync> Sync for Error<T> {}
+
+impl From<Error<dyn Send>> for Error {
+    fn from(value: Error<dyn Send>) -> Self {
+        Self(value.into_error(), PhantomData)
+    }
+}
+
+impl From<Error<dyn Sync>> for Error {
+    fn from(value: Error<dyn Sync>) -> Self {
+        Self(value.into_error(), PhantomData)
+    }
+}
+
+impl From<Error<dyn Send + Sync>> for Error {
+    fn from(value: Error<dyn Send + Sync>) -> Self {
+        Self(value.into_error(), PhantomData)
+    }
+}
+
+impl From<Error<dyn Send + Sync>> for Error<dyn Send> {
+    fn from(value: Error<dyn Send + Sync>) -> Self {
+        Self(value.into_error(), PhantomData)
+    }
+}
+
+impl From<Error<dyn Send + Sync>> for Error<dyn Sync> {
+    fn from(value: Error<dyn Send + Sync>) -> Self {
+        Self(value.into_error(), PhantomData)
+    }
+}
+
+trait NewErrorSpec<T>
+where
+    T: 'static,
+{
+    fn new_error(value: T) -> Self;
+}
+
+impl<T> NewErrorSpec<T> for Error
+where
+    T: fmt::Debug + fmt::Display + 'static,
+{
+    default fn new_error(value: T) -> Self {
+        fn new_string(string: String) -> bindings::FimoResultString {
+            extern "C" fn release(ffi: *const std::ffi::c_char) {
+                let ffi = ffi.cast_mut();
+                // Safety: We know that it is a valid string.
+                unsafe {
+                    let _ = CString::from_raw(ffi);
+                }
+            }
+
+            match CString::new(string) {
+                Ok(string) => bindings::FimoResultString {
+                    str_: string.into_raw(),
+                    release: Some(release),
+                },
+                Err(_) => <Error>::from_string(c"CString::new failed")
+                    .description()
+                    .into_ffi(),
+            }
+        }
+
+        extern "C" fn drop_inline<T>(mut ffi: *mut std::ffi::c_void) {
+            let value_ptr: *mut T = std::ptr::from_mut(&mut ffi).cast();
+            // Safety: The value is valid.
+            unsafe { std::ptr::drop_in_place::<T>(value_ptr) };
+        }
+        extern "C" fn debug_inline<T: fmt::Debug>(
+            ffi: *mut std::ffi::c_void,
+        ) -> bindings::FimoResultString {
+            let value_ptr: *const T = std::ptr::from_ref(&ffi).cast();
+            // Safety: The value is valid.
+            unsafe {
+                let value = &*value_ptr;
+                new_string(format!("{:?}", *value))
+            }
+        }
+        extern "C" fn display_inline<T: fmt::Display>(
+            ffi: *mut std::ffi::c_void,
+        ) -> bindings::FimoResultString {
+            let value_ptr: *const T = std::ptr::from_ref(&ffi).cast();
+            // Safety: The value is valid.
+            unsafe {
+                let value = &*value_ptr;
+                new_string(format!("{}", *value))
+            }
+        }
+
+        // If the size and alignments match we can store the value inline.
+        if size_of::<T>() <= size_of::<*mut std::ffi::c_void>()
+            && align_of::<T>() <= align_of::<*mut std::ffi::c_void>()
+        {
+            let vtable: &'static bindings::FimoResultVTable = &const {
+                bindings::FimoResultVTable {
+                    v0: bindings::FimoResultVTableV0 {
+                        release: if std::mem::needs_drop::<T>() {
+                            Some(drop_inline::<T>)
+                        } else {
+                            None
+                        },
+                        error_name: Some(debug_inline::<T>),
+                        error_description: Some(display_inline::<T>),
+                    },
+                }
+            };
+
+            let value = ManuallyDrop::new(value);
+            // Safety: We checked that it is safe.
+            let data = unsafe { std::mem::transmute_copy(&value) };
+            let error = bindings::FimoResult { data, vtable };
+            return Self(error, PhantomData);
+        }
+
+        extern "C" fn drop_boxed<T>(ffi: *mut std::ffi::c_void) {
+            let value_ptr: *mut T = ffi.cast();
+            // Safety: The value is valid.
+            unsafe { drop(Box::<T>::from_raw(value_ptr)) };
+        }
+        extern "C" fn debug_boxed<T: fmt::Debug>(
+            ffi: *mut std::ffi::c_void,
+        ) -> bindings::FimoResultString {
+            let value_ptr: *const T = ffi.cast();
+            // Safety: The value is valid.
+            unsafe {
+                let value = &*value_ptr;
+                new_string(format!("{:?}", *value))
+            }
+        }
+        extern "C" fn display_boxed<T: fmt::Display>(
+            ffi: *mut std::ffi::c_void,
+        ) -> bindings::FimoResultString {
+            let value_ptr: *const T = ffi.cast();
+            // Safety: The value is valid.
+            unsafe {
+                let value = &*value_ptr;
+                new_string(format!("{}", *value))
+            }
+        }
+
+        // Fall back to boxing the error.
+        let vtable: &'static bindings::FimoResultVTable = &const {
+            bindings::FimoResultVTable {
+                v0: bindings::FimoResultVTableV0 {
+                    release: Some(drop_boxed::<T>),
+                    error_name: Some(debug_boxed::<T>),
+                    error_description: Some(display_boxed::<T>),
+                },
+            }
+        };
+
+        let value = Box::new(value);
+        let data = Box::into_raw(value).cast();
+        let error = bindings::FimoResult { data, vtable };
+        Self(error, PhantomData)
+    }
+}
+
+impl<T: ?Sized> FFITransferable<bindings::FimoResult> for Error<T> {
+    fn into_ffi(self) -> bindings::FimoResult {
+        self.into_error()
+    }
+
+    unsafe fn from_ffi(ffi: bindings::FimoResult) -> Self {
+        Self(ffi, PhantomData)
+    }
+}
+
+/// A string returned from an `Error`.
+pub struct ErrorString(bindings::FimoResultString);
+
+// Safety: Is only a `&CStr`.
+unsafe impl Send for ErrorString {}
+
+// Safety: Is only a `&CStr`.
+unsafe impl Sync for ErrorString {}
+
+impl Deref for ErrorString {
+    type Target = CStr;
+
+    fn deref(&self) -> &Self::Target {
+        // Safety: The string is always valid.
+        unsafe { CStr::from_ptr(self.0.str_) }
+    }
+}
+
+impl Drop for ErrorString {
+    fn drop(&mut self) {
+        if let Some(release) = self.0.release {
+            // Safety: The function is safe to be called.
+            unsafe { release(self.0.str_) }
+        }
+    }
+}
+
+impl FFITransferable<bindings::FimoResultString> for ErrorString {
+    fn into_ffi(self) -> bindings::FimoResultString {
+        let this = ManuallyDrop::new(self);
+        this.0
+    }
+
+    unsafe fn from_ffi(ffi: bindings::FimoResultString) -> Self {
+        Self(ffi)
     }
 }
 
 /// A [`Result`] with an [`Error`] error type.
 pub type Result<T = (), E = Error> = core::result::Result<T, E>;
 
-/// Converts a [`FimoError`](bindings::FimoError) to an error if it's greater than zero, and
+/// Converts a [`FimoResult`](bindings::FimoResult) to an error if it's greater than zero, and
 /// `Ok(())` otherwise.
-pub fn to_result(error: bindings::FimoError) -> Result {
-    if error.0 > 0 {
-        Err(Error::from_error(error))
+///
+/// # Safety
+///
+/// - `error` must be properly initialized.
+pub unsafe fn to_result(error: bindings::FimoResult) -> Result {
+    if !error.data.is_null() {
+        Err(Error(error, PhantomData))
     } else {
         Ok(())
     }
@@ -279,16 +683,20 @@ pub fn to_result(error: bindings::FimoError) -> Result {
 /// # use fimo_std::error:to_result_indirect;
 /// # use fimo_std::bindings;
 /// extern "C" {
-///     fn my_func(error: *mut bindings::FimoError);
+///     fn my_func(error: *mut bindings::FimoErrorCode);
 /// }
 ///
-/// to_result_indirect(|error| unsafe { my_func(error) });
+/// unsafe { to_result_indirect(|error| my_func(error)) };
 /// ```
-pub fn to_result_indirect<T>(f: impl FnOnce(&mut bindings::FimoError) -> T) -> Result<T> {
-    let mut error = Error::EOK.into_error();
+///
+/// # Safety
+///
+/// - `error` must be properly initialized by `f`.
+pub unsafe fn to_result_indirect<T>(f: impl FnOnce(&mut bindings::FimoResult) -> T) -> Result<T> {
+    let mut error = <Error>::FFI_OK_RESULT;
     let result = f(&mut error);
-    if error.0 != bindings::FimoError::FIMO_EOK.0 {
-        Err(Error::from_error(error))
+    if !error.vtable.is_null() {
+        Err(Error(error, PhantomData))
     } else {
         Ok(result)
     }
@@ -304,7 +712,7 @@ pub fn to_result_indirect<T>(f: impl FnOnce(&mut bindings::FimoError) -> T) -> R
 /// # use fimo_std::error:to_result_indirect;
 /// # use fimo_std::bindings;
 /// extern "C" {
-///     fn my_func(error: *mut bindings::FimoError, data: *mut u32);
+///     fn my_func(error: *mut bindings::FimoResult, data: *mut u32);
 /// }
 ///
 /// unsafe {
@@ -314,20 +722,38 @@ pub fn to_result_indirect<T>(f: impl FnOnce(&mut bindings::FimoError) -> T) -> R
 ///
 /// # Safety
 ///
-/// The closure must initialize the data or write an error in the first parameter.
+/// - `f` must initialize the data or write an error in the first parameter.
 pub unsafe fn to_result_indirect_in_place<T>(
-    f: impl FnOnce(&mut bindings::FimoError, &mut MaybeUninit<T>),
+    f: impl FnOnce(&mut bindings::FimoResult, &mut MaybeUninit<T>),
 ) -> Result<T> {
     let mut data = MaybeUninit::<T>::uninit();
-    let mut error = Error::EOK.into_error();
+    let mut error = <Error>::FFI_OK_RESULT;
+
     f(&mut error, &mut data);
-    if error.0 != bindings::FimoError::FIMO_EOK.0 {
-        Err(Error::from_error(error))
+    if !error.vtable.is_null() {
+        Err(Error(error, PhantomData))
     } else {
         // Safety: By the contract of this function the data
         // must have been initialized, if the function does
         // not return an error.
         let result = unsafe { data.assume_init() };
         Ok(result)
+    }
+}
+
+impl<T: ?Sized> FFITransferable<bindings::FimoResult> for Result<(), Error<T>> {
+    fn into_ffi(self) -> bindings::FimoResult {
+        match self {
+            Ok(_) => <Error>::FFI_OK_RESULT,
+            Err(x) => x.into_error(),
+        }
+    }
+
+    unsafe fn from_ffi(ffi: bindings::FimoResult) -> Self {
+        if !ffi.vtable.is_null() {
+            Err(Error(ffi, PhantomData))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/rust/fimo_std/src/graph.rs
+++ b/rust/fimo_std/src/graph.rs
@@ -582,8 +582,8 @@ impl<N, E> Graph<N, E> {
                     &mut src.0,
                     &mut dst.0,
                 );
-            })?
-        };
+            })?;
+        }
 
         Ok((src, dst))
     }
@@ -1759,8 +1759,8 @@ impl Iterator for NodesInner {
             to_result_indirect(|error| {
                 *error = bindings::fimo_graph_nodes_next(self.ptr.as_ptr(), &mut self.has_next);
             })
-            .expect("the iterator should be valid")
-        };
+            .expect("the iterator should be valid");
+        }
 
         Some((node, data))
     }

--- a/rust/fimo_std/src/lib.rs
+++ b/rust/fimo_std/src/lib.rs
@@ -4,9 +4,11 @@
 #![feature(allocator_api)]
 #![feature(panic_update_hook)]
 #![feature(result_flattening)]
+#![feature(strict_provenance)]
 #![feature(maybe_uninit_slice)]
 #![feature(vec_into_raw_parts)]
 #![feature(min_specialization)]
+#![feature(const_refs_to_static)]
 
 extern crate alloc;
 

--- a/rust/fimo_std/src/module/module_info.rs
+++ b/rust/fimo_std/src/module/module_info.rs
@@ -103,9 +103,11 @@ impl ModuleInfoView<'_> {
     /// except if they are a pseudo module.
     pub fn unload(&self, ctx: &impl ModuleSubsystem) -> error::Result {
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_unload(ctx.share_to_ffi(), self.share_to_ffi());
-        })
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_unload(ctx.share_to_ffi(), self.share_to_ffi());
+            })
+        }
     }
 
     /// Checks whether the underlying module is still loaded.
@@ -121,9 +123,11 @@ impl ModuleInfoView<'_> {
     pub fn lock_unload(&self) -> Result<ModuleInfoGuard<'_>, Error> {
         let lock_unload = self.0.lock_unload.unwrap();
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = lock_unload(self.share_to_ffi());
-        })?;
+        unsafe {
+            to_result_indirect(|error| {
+                *error = lock_unload(self.share_to_ffi());
+            })?;
+        }
         Ok(ModuleInfoGuard(*self))
     }
 
@@ -528,7 +532,10 @@ unsafe impl Module for OpaqueModule<'_> {
                 &mut is_static,
             )
         };
-        to_result(error)?;
+        // Safety:
+        unsafe {
+            to_result(error)?;
+        }
 
         match (has_dependency, is_static) {
             (true, true) => Ok(DependencyType::StaticDependency),
@@ -542,7 +549,8 @@ unsafe impl Module for OpaqueModule<'_> {
         let error = unsafe {
             bindings::fimo_module_namespace_include(self.share_to_ffi(), namespace.as_ptr())
         };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     unsafe fn exclude_namespace(&self, namespace: &CStr) -> error::Result {
@@ -550,7 +558,8 @@ unsafe impl Module for OpaqueModule<'_> {
         let error = unsafe {
             bindings::fimo_module_namespace_exclude(self.share_to_ffi(), namespace.as_ptr())
         };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     fn has_dependency(&self, module: &ModuleInfoView<'_>) -> Result<DependencyType, Error> {
@@ -566,7 +575,10 @@ unsafe impl Module for OpaqueModule<'_> {
                 &mut is_static,
             )
         };
-        to_result(error)?;
+        // Safety:
+        unsafe {
+            to_result(error)?;
+        }
 
         match (has_dependency, is_static) {
             (true, true) => Ok(DependencyType::StaticDependency),
@@ -580,7 +592,8 @@ unsafe impl Module for OpaqueModule<'_> {
         let error = unsafe {
             bindings::fimo_module_acquire_dependency(self.share_to_ffi(), dependency.share_to_ffi())
         };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     unsafe fn remove_dependency(&self, dependency: ModuleInfoView<'_>) -> error::Result {
@@ -588,7 +601,8 @@ unsafe impl Module for OpaqueModule<'_> {
         let error = unsafe {
             bindings::fimo_module_relinquish_dependency(self.share_to_ffi(), dependency.into_ffi())
         };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     unsafe fn load_symbol_unchecked<T>(

--- a/rust/fimo_std/src/module/parameter.rs
+++ b/rust/fimo_std/src/module/parameter.rs
@@ -181,15 +181,17 @@ impl ParameterValue {
         let mut type_ = bindings::FimoModuleParamType::FIMO_MODULE_PARAM_TYPE_U8;
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_get_public(
-                ctx.share_to_ffi(),
-                core::ptr::from_mut(&mut value).cast(),
-                &mut type_,
-                module.as_ptr(),
-                parameter.as_ptr(),
-            );
-        })?;
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_get_public(
+                    ctx.share_to_ffi(),
+                    core::ptr::from_mut(&mut value).cast(),
+                    &mut type_,
+                    module.as_ptr(),
+                    parameter.as_ptr(),
+                );
+            })?;
+        }
         let type_ = ParameterType::try_from(type_)?;
 
         // Safety: We checked the type tag.
@@ -221,15 +223,17 @@ impl ParameterValue {
         let mut type_ = bindings::FimoModuleParamType::FIMO_MODULE_PARAM_TYPE_U8;
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_get_dependency(
-                caller.share_to_ffi(),
-                core::ptr::from_mut(&mut value).cast(),
-                &mut type_,
-                module.as_ptr(),
-                parameter.as_ptr(),
-            );
-        })?;
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_get_dependency(
+                    caller.share_to_ffi(),
+                    core::ptr::from_mut(&mut value).cast(),
+                    &mut type_,
+                    module.as_ptr(),
+                    parameter.as_ptr(),
+                );
+            })?;
+        }
         let type_ = ParameterType::try_from(type_)?;
 
         // Safety: We checked the type tag.
@@ -256,14 +260,16 @@ impl ParameterValue {
         let mut type_ = bindings::FimoModuleParamType::FIMO_MODULE_PARAM_TYPE_U8;
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_get_private(
-                caller.share_to_ffi(),
-                core::ptr::from_mut(&mut value).cast(),
-                &mut type_,
-                parameter.share_to_ffi(),
-            );
-        })?;
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_get_private(
+                    caller.share_to_ffi(),
+                    core::ptr::from_mut(&mut value).cast(),
+                    &mut type_,
+                    parameter.share_to_ffi(),
+                );
+            })?;
+        }
         let type_ = ParameterType::try_from(type_)?;
 
         // Safety: We checked the type tag.
@@ -290,14 +296,16 @@ impl ParameterValue {
         let mut type_ = bindings::FimoModuleParamType::FIMO_MODULE_PARAM_TYPE_U8;
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_get_inner(
-                caller.share_to_ffi(),
-                core::ptr::from_mut(&mut value).cast(),
-                &mut type_,
-                parameter.get(),
-            );
-        })?;
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_get_inner(
+                    caller.share_to_ffi(),
+                    core::ptr::from_mut(&mut value).cast(),
+                    &mut type_,
+                    parameter.get(),
+                );
+            })?;
+        }
         let type_ = ParameterType::try_from(type_)?;
 
         // Safety: We checked the type tag.
@@ -338,15 +346,17 @@ impl ParameterValue {
         };
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_set_public(
-                ctx.share_to_ffi(),
-                core::ptr::from_ref(&value).cast(),
-                type_.into_ffi(),
-                module.as_ptr(),
-                parameter.as_ptr(),
-            );
-        })
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_set_public(
+                    ctx.share_to_ffi(),
+                    core::ptr::from_ref(&value).cast(),
+                    type_.into_ffi(),
+                    module.as_ptr(),
+                    parameter.as_ptr(),
+                );
+            })
+        }
     }
 
     /// Writes a module parameter with dependency write access.
@@ -372,15 +382,17 @@ impl ParameterValue {
         };
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_set_dependency(
-                caller.share_to_ffi(),
-                core::ptr::from_ref(&value).cast(),
-                type_.into_ffi(),
-                module.as_ptr(),
-                parameter.as_ptr(),
-            );
-        })
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_set_dependency(
+                    caller.share_to_ffi(),
+                    core::ptr::from_ref(&value).cast(),
+                    type_.into_ffi(),
+                    module.as_ptr(),
+                    parameter.as_ptr(),
+                );
+            })
+        }
     }
 
     /// Writes a module parameter.
@@ -401,14 +413,16 @@ impl ParameterValue {
         };
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_set_private(
-                caller.share_to_ffi(),
-                core::ptr::from_ref(&value).cast(),
-                type_.into_ffi(),
-                parameter.share_to_ffi(),
-            );
-        })
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_set_private(
+                    caller.share_to_ffi(),
+                    core::ptr::from_ref(&value).cast(),
+                    type_.into_ffi(),
+                    parameter.share_to_ffi(),
+                );
+            })
+        }
     }
 
     /// Writes a module parameter.
@@ -429,14 +443,16 @@ impl ParameterValue {
         };
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_set_inner(
-                caller.share_to_ffi(),
-                core::ptr::from_ref(&value).cast(),
-                type_.into_ffi(),
-                parameter.get(),
-            );
-        })
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_set_inner(
+                    caller.share_to_ffi(),
+                    core::ptr::from_ref(&value).cast(),
+                    type_.into_ffi(),
+                    parameter.get(),
+                );
+            })
+        }
     }
 }
 
@@ -475,16 +491,18 @@ impl ParameterInfo {
         let mut write = bindings::FimoModuleParamAccess::FIMO_MODULE_PARAM_ACCESS_PRIVATE;
 
         // Safety: The ffi call is safe.
-        to_result_indirect(|error| unsafe {
-            *error = bindings::fimo_module_param_query(
-                ctx.share_to_ffi(),
-                module.as_ptr(),
-                parameter.as_ptr(),
-                &mut type_,
-                &mut read,
-                &mut write,
-            );
-        })?;
+        unsafe {
+            to_result_indirect(|error| {
+                *error = bindings::fimo_module_param_query(
+                    ctx.share_to_ffi(),
+                    module.as_ptr(),
+                    parameter.as_ptr(),
+                    &mut type_,
+                    &mut read,
+                    &mut write,
+                );
+            })?;
+        }
 
         let type_ = TryFrom::try_from(type_)?;
         let read = TryFrom::try_from(read)?;

--- a/rust/fimo_std/src/refcount.rs
+++ b/rust/fimo_std/src/refcount.rs
@@ -88,7 +88,8 @@ impl RefCount {
     pub unsafe fn upgrade(&self) -> crate::error::Result {
         // Safety: The pointer is valid and we own a weak reference.
         let error = unsafe { bindings::fimo_upgrade_refcount(self.0.get()) };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     /// Downgrades a strong reference to a weak reference.
@@ -102,7 +103,8 @@ impl RefCount {
     pub unsafe fn downgrade(&self) -> crate::error::Result {
         // Safety: The pointer is valid and we own a weak reference.
         let error = unsafe { bindings::fimo_downgrade_refcount(self.0.get()) };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     /// Returns whether there is only one strong reference left.
@@ -213,7 +215,8 @@ impl ARefCount {
     pub unsafe fn upgrade(&self) -> crate::error::Result {
         // Safety: The pointer is valid and we own a weak reference.
         let error = unsafe { bindings::fimo_upgrade_refcount_atomic(self.0.get()) };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     /// Downgrades a strong reference to a weak reference.
@@ -227,7 +230,8 @@ impl ARefCount {
     pub unsafe fn downgrade(&self) -> crate::error::Result {
         // Safety: The pointer is valid and we own a weak reference.
         let error = unsafe { bindings::fimo_downgrade_refcount_atomic(self.0.get()) };
-        to_result(error)
+        // Safety:
+        unsafe { to_result(error) }
     }
 
     /// Returns whether there is only one strong reference left.

--- a/rust/fimo_std/src/tracing.rs
+++ b/rust/fimo_std/src/tracing.rs
@@ -568,8 +568,8 @@ impl Drop for Span {
             to_result_indirect(|error| {
                 *error = bindings::fimo_tracing_span_destroy(self.0.share_to_ffi(), self.1);
             })
-            .expect("the span should be destroyable")
-        };
+            .expect("the span should be destroyable");
+        }
     }
 }
 

--- a/rust/fimo_std/src/version.rs
+++ b/rust/fimo_std/src/version.rs
@@ -94,7 +94,10 @@ impl Version {
                 &mut written,
             )
         };
-        to_result(error)?;
+        // Safety:
+        unsafe {
+            to_result(error)?;
+        }
 
         let (str_buf, _) = buff.split_at_mut(written);
 
@@ -123,7 +126,10 @@ impl Version {
                 &mut written,
             )
         };
-        to_result(error)?;
+        // Safety:
+        unsafe {
+            to_result(error)?;
+        }
 
         let (str_buf, _) = buff.split_at_mut(written);
 

--- a/rust/fimo_tasks/src/command_buffer.rs
+++ b/rust/fimo_tasks/src/command_buffer.rs
@@ -858,7 +858,7 @@ where
     fn block_on(self, group: &WorkerGroup<'ctx>) -> Result<CommandBufferStatus, Error> {
         if group.is_worker() {
             let handle = self.enqueue(group, |_| {})?;
-            handle.join().map_err(|err| err.error())
+            handle.join().map_err(|err| err.into_error())
         } else {
             let sync_arc =
                 Arc::new_in((Mutex::new(None), Condvar::new()), self.allocator().clone());
@@ -1009,8 +1009,13 @@ unsafe impl Sync for CommandBufferHandleInner<'_> {}
 pub struct CommandBufferHandleError<'ctx, A: Allocator>(CommandBufferHandle<'ctx, A>, Error);
 
 impl<'ctx, A: Allocator> CommandBufferHandleError<'ctx, A> {
-    /// Returns the contained error code.
-    pub fn error(&self) -> Error {
+    /// Returns the contained error.
+    pub fn error(&self) -> &Error {
+        &self.1
+    }
+
+    /// Extracts the contained error.
+    pub fn into_error(self) -> Error {
         self.1
     }
 

--- a/rust/fimo_tasks/src/task.rs
+++ b/rust/fimo_tasks/src/task.rs
@@ -74,7 +74,7 @@ where
                 let context = Context(context);
                 // Safety: FFI call is safe
                 unsafe {
-                    (context.vtable().v0.abort.unwrap_unchecked())(
+                    context.vtable().v0.abort.unwrap_unchecked()(
                         context.data(),
                         std::ptr::null_mut(),
                     )

--- a/rust/fimo_tasks/src/worker_group.rs
+++ b/rust/fimo_tasks/src/worker_group.rs
@@ -31,26 +31,26 @@ impl WorkerGroup<'_> {
     /// Returns the unique id of the worker group.
     pub fn id(&self) -> WorkerGroupId {
         // Safety: FFI call is safe
-        let id = unsafe { (self.vtable().v0.id.unwrap_unchecked())(self.data()) };
+        let id = unsafe { self.vtable().v0.id.unwrap_unchecked()(self.data()) };
         WorkerGroupId(id)
     }
 
     /// Checks whether the worker group is open to receive new commands.
     pub fn is_open(&self) -> bool {
         // Safety: FFI call is safe
-        unsafe { (self.vtable().v0.is_open.unwrap_unchecked())(self.data()) }
+        unsafe { self.vtable().v0.is_open.unwrap_unchecked()(self.data()) }
     }
 
     /// Checks whether the current thread is a worker thread of the group.
     pub fn is_worker(&self) -> bool {
         // Safety: FFI call is safe
-        unsafe { (self.vtable().v0.is_worker.unwrap_unchecked())(self.data()) }
+        unsafe { self.vtable().v0.is_worker.unwrap_unchecked()(self.data()) }
     }
 
     /// Returns the name of the worker.
     pub fn name(&self) -> &CStr {
         // Safety: FFI call is safe
-        let name = unsafe { (self.vtable().v0.name.unwrap_unchecked())(self.data()) };
+        let name = unsafe { self.vtable().v0.name.unwrap_unchecked()(self.data()) };
 
         // Safety: The function is guaranteed to return a null-terminated string.
         unsafe { CStr::from_ptr(name) }
@@ -64,7 +64,7 @@ impl WorkerGroup<'_> {
         // Safety: FFI call is safe
         unsafe {
             to_result_indirect(|err| {
-                *err = (self.vtable().v0.request_close.unwrap_unchecked())(self.data());
+                *err = self.vtable().v0.request_close.unwrap_unchecked()(self.data());
             })
         }
     }
@@ -75,7 +75,7 @@ impl WorkerGroup<'_> {
         // Safety: FFI call is safe
         let workers = unsafe {
             to_result_indirect_in_place(|err, workers| {
-                *err = (self.vtable().v0.workers.unwrap_unchecked())(
+                *err = self.vtable().v0.workers.unwrap_unchecked()(
                     self.data(),
                     workers.as_mut_ptr(),
                     &mut num_workers,
@@ -104,7 +104,7 @@ impl WorkerGroup<'_> {
         // Safety: FFI call is safe
         let sizes = unsafe {
             to_result_indirect_in_place(|err, sizes| {
-                *err = (self.vtable().v0.workers.unwrap_unchecked())(
+                *err = self.vtable().v0.stack_sizes.unwrap_unchecked()(
                     self.data(),
                     sizes.as_mut_ptr(),
                     &mut num_stacks,
@@ -151,7 +151,7 @@ impl std::fmt::Debug for WorkerGroup<'_> {
 impl Clone for WorkerGroup<'_> {
     fn clone(&self) -> Self {
         // Safety: We own the reference therefore we can acquire another one.
-        unsafe { (self.vtable().v0.acquire.unwrap_unchecked())(self.data()) }
+        unsafe { self.vtable().v0.acquire.unwrap_unchecked()(self.data()) }
         Self(self.0, PhantomData)
     }
 }
@@ -159,7 +159,7 @@ impl Clone for WorkerGroup<'_> {
 impl Drop for WorkerGroup<'_> {
     fn drop(&mut self) {
         // Safety: We own the reference therefore we can release it.
-        unsafe { (self.vtable().v0.release.unwrap_unchecked())(self.data()) }
+        unsafe { self.vtable().v0.release.unwrap_unchecked()(self.data()) }
     }
 }
 
@@ -332,7 +332,7 @@ impl<'a> WorkerGroupBuilder<'a> {
         // Safety: FFI call is safe
         let group = unsafe {
             to_result_indirect_in_place(|err, group| {
-                *err = (ctx.vtable().v0.create_worker_group.unwrap_unchecked())(
+                *err = ctx.vtable().v0.create_worker_group.unwrap_unchecked()(
                     ctx.data(),
                     config,
                     group.as_mut_ptr(),


### PR DESCRIPTION
Introduces the following changes:

- Renames `FimoError` to `FimoErrorCode`.
- Adds `FimoSystemErrorCode` to expose native system errors.
- Introduces `FimoResult` as a wrapper around arbitrary errors.