### PR TITLE
Add interface to request a symbol from an instance

### DIFF
--- a/ffi_library/fimo_python_meta/src/root.zig
+++ b/ffi_library/fimo_python_meta/src/root.zig
@@ -22,7 +22,7 @@ pub const symbols = struct {
             .minor = c.FIPY_SYMBOL_VERSION_MINOR_RUN_STRING,
             .patch = c.FIPY_SYMBOL_VERSION_PATCH_RUN_STRING,
         },
-        .symbol = Root.RunString,
+        .T = Root.RunString,
     };
 };
 

--- a/modules/fimo_python/src/root.zig
+++ b/modules/fimo_python/src/root.zig
@@ -146,21 +146,21 @@ const State = struct {
         PyConfig_InitIsolatedConfig(&cfg);
         defer PyConfig_Clear(&cfg);
 
-        var status = PyConfig_SetBytesString(&cfg, &cfg.home, ctx.resources.home.cStr());
+        var status = PyConfig_SetBytesString(&cfg, &cfg.home, ctx.resources().home.cStr());
         if (PyStatus_Exception(status) != 0) return error.HomeConfig;
 
-        status = PyConfig_SetBytesString(&cfg, &cfg.program_name, ctx.resources.module_path.cStr());
+        status = PyConfig_SetBytesString(&cfg, &cfg.program_name, ctx.resources().module_path.cStr());
         if (PyStatus_Exception(status) != 0) return error.ProgramNameConfig;
 
         cfg.module_search_paths_set = 1;
-        const lib_path = Py_DecodeLocale(ctx.resources.lib_path.cStr(), null);
+        const lib_path = Py_DecodeLocale(ctx.resources().lib_path.cStr(), null);
         defer if (lib_path != null) PyMem_RawFree(lib_path);
         if (lib_path == null) return error.DecodeLibPath;
         status = PyWideStringList_Append(&cfg.module_search_paths, lib_path);
         if (PyStatus_Exception(status) != 0) return error.AppendLibPath;
 
         if (builtin.target.os.tag == .windows) {
-            const dynload_path = Py_DecodeLocale(ctx.resources.dynload_path.cStr(), null);
+            const dynload_path = Py_DecodeLocale(ctx.resources().dynload_path.cStr(), null);
             defer if (dynload_path != null) PyMem_RawFree(dynload_path);
             if (dynload_path == null) return error.DecodeDynloadPath;
             status = PyWideStringList_Append(&cfg.module_search_paths, dynload_path);

--- a/modules/fimo_python/tests/run_string.zig
+++ b/modules/fimo_python/tests/run_string.zig
@@ -69,7 +69,7 @@ pub fn main() !void {
     try instance.addNamespace(fimo_python_meta.symbols.RunString.namespace, &err);
     const run_string = try instance.loadSymbol(fimo_python_meta.symbols.RunString, &err);
 
-    try run_string.call(
+    try run_string.value.call(
         \\import sys
         \\
         \\print("Hello Python!", file=sys.stderr)


### PR DESCRIPTION
Changes the `Instance` definition to accept a configuration structure. Additionally, this introduces the `SymbolWrapper` type, which, with module instances, declares the `provideSymbol` function to request a specific symbol by its type.`